### PR TITLE
Allow to define sources via yaml

### DIFF
--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+
+{{/*
+Define the value of the sources parameter based on the definition of multiple or a single source
+*/}}
+{{- define "sources" -}}
+{{- $inline := printf "postgresql://$PGWATCH_USER:$PGWATCH_USER_PASSWORD@$METRIC_DATABASE_ENDPOINT:$METRIC_DATABASE_PORT/$METRIC_DATABASE_DATABASE?sslmode=$METRIC_DATABASE_SSLMODE"  -}}
+{{- $file := "/etc/sources.yaml" -}}
+
+{{- if .Values.pgwatch.postgres.sources -}}
+  {{- $file -}}
+{{- else -}}
+  {{- $inline -}}
+{{- end -}}
+{{- end -}}

--- a/helm/pgwatch/templates/grafana-deployment.yaml
+++ b/helm/pgwatch/templates/grafana-deployment.yaml
@@ -50,7 +50,7 @@ spec:
                 secretKeyRef:
                   name: pgwatch-postgresql-secret-pgwatch
                   key: password
-            {{- else }}
+            {{- else if .Values.pgwatch.postgres.use_existing_database }}
             - name: GF_DATABASE_TYPE
               value: postgres
             - name: GF_DATABASE_HOST
@@ -131,7 +131,7 @@ data:
       postgresVersion: 1700
       version: 1
       editable: true
-  {{- else }}
+  {{- else if .Values.pgwatch.postgres.use_existing_database }}
   postgres_datasource.yml: |
     apiVersion: 1
     datasources:

--- a/helm/pgwatch/templates/pgwatch-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-config.yaml
@@ -9,7 +9,7 @@ data:
   launcher.sh: |
     #!/bin/sh
 
-    CMD="/pgwatch/pgwatch --sources=postgresql://$PGWATCH_USER:$PGWATCH_USER_PASSWORD@$METRIC_DATABASE_ENDPOINT:$METRIC_DATABASE_PORT/$METRIC_DATABASE_DATABASE?sslmode=$METRIC_DATABASE_SSLMODE"
+    CMD="/pgwatch/pgwatch --sources={{ include "sources" .}}"
 
     if [[ "$PG_IS_SINK" == "true" ]]; then
         CMD="$CMD --sink=postgresql://$PGWATCH_USER:$PGWATCH_USER_PASSWORD@$METRIC_DATABASE_ENDPOINT:$METRIC_DATABASE_PORT/$METRIC_DATABASE_DATABASE?sslmode=$METRIC_DATABASE_SSLMODE --retention=$PG_RETENTION_DAYS"
@@ -20,4 +20,8 @@ data:
     fi
 
     exec $CMD
-
+  
+  sources.yaml: |
+    {{- if .Values.pgwatch.postgres.sources }}
+      {{- toYaml .Values.pgwatch.postgres.sources | nindent 4 }}
+    {{- end }}

--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             value: pgwatch_metrics
           - name: METRIC_DATABASE_SSLMODE
             value: disable
-        {{- else }}
+        {{- else if .Values.pgwatch.postgres.use_existing_database }}
           - name: PGWATCH_USER
             value: {{ .Values.pgwatch.postgres.use_existing_database.username }}
           - name: PGWATCH_USER_PASSWORD
@@ -65,9 +65,14 @@ spec:
         {{ end }}
           image: {{ .Values.pgwatch.image }}
           volumeMounts:
-          - name: launcher
+          - name: configuration
             mountPath: /tmp/launcher.sh
             subPath: launcher.sh
+        {{if .Values.pgwatch.postgres.sources}}
+          - name: configuration
+            mountPath: /etc/sources.yaml
+            subPath: sources.yaml
+        {{ end }}
           name: pgwatch
           ports:
             - containerPort: 8080
@@ -78,9 +83,10 @@ spec:
         {{ end }}
           command: ["/tmp/launcher.sh"]
       volumes:
-      - name: launcher
+      - name: configuration
         configMap:
           name: pgwatch-cm
           defaultMode: 0777  # Damit es direkt ausführbar ist
       restartPolicy: Always
+
 

--- a/helm/pgwatch/templates/services.yaml
+++ b/helm/pgwatch/templates/services.yaml
@@ -10,7 +10,7 @@ spec:
     - name: pgwatch
       port: 8080
       targetPort: 8080
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if or ( eq .Values.pgwatch.prometheus.enable_prom_sink "true" ) (.Values.pgwatch.prometheus.new_prometheus.create_prometheus "true")  }}
     - name: pgwatch-prometheus-sink
       port: 9188
       targetPort: 9188    
@@ -19,6 +19,7 @@ spec:
     application: pgwatch
     pgwatch.pods.role: pgwatch
 ---
+{{ if eq .Values.pgwatch.grafana.enable_grafana "true" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -34,6 +35,7 @@ spec:
   selector:
     application: pgwatch
     pgwatch.pods.role: grafana
+{{ end }}
 ---
 {{- if eq .Values.pgwatch.postgres.create_metric_database "true" }}
 apiVersion: v1

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -2,12 +2,14 @@ pgwatch:
   image: "docker.io/cybertecpostgresql/pgwatch:latest"
   namespace: pgwatch
   postgres:
+    enable_service_monitor: "true"
     enable_pg_sink: "true"
-    settings: 
+    settings:
       retention_days: 31
     # define is a database for the metrics needs to be created or if there is already an existing database
     create_metric_database: "true" #"false"
-    new_pg_database: # Will be used for pgqwatch config only, if enable_pg_sink = "false"
+    new_pg_database:
+      # Will be used for pgqwatch config only, if enable_pg_sink = "false"
       image: "docker.io/schmaetz/postgres:bookworm-17.4-1"
       volume:
         size: '10Gi'
@@ -19,7 +21,30 @@ pgwatch:
     #   sslmode:  require
     #   username: pgwatch_user
     #   password: PASSWORD_FOR_PGWATCH_USER
-  prometheus: 
+    sources: {}
+      #- name: test1       # An arbitrary unique name for the monitored source
+      #  kind: postgres    # One of the:
+      #                      # - postgres
+      #                      # - postgres-continuous-discovery
+      #                      # - pgbouncer
+      #                      # - pgpool
+      #                      # - patroni
+      #                      # - patroni-continuous-discovery
+      #                      # - patroni-namespace-discover
+      #                      # Defaults to postgres if not specified
+      #  conn_str: postgresql://pgwatch:xyz@somehost/mydb
+      #  preset_metrics: exhaustive # from list of presets defined in "metrics/preset-configs.yaml"
+      #  custom_metrics:    # if both preset and custom are specified, custom wins
+      #  preset_metrics_standby: # optional metrics configuration for standby / replica state, v1.8.1+
+      #  custom_metrics_standby:
+      #  include_pattern: # regex to filter databases to actually monitor for the "continuous" modes
+      #  exclude_pattern:
+      #  is_enabled: true
+      #  group: default # just for logical grouping of DB hosts or for "sharding", i.e. splitting the workload between many gatherer daemons
+      #  custom_tags:      # option to add arbitrary tags for every stored data row,
+      #      aws_instance_id: i-0af01c0123456789a       # for example to fetch data from some other source onto a same Grafana graph
+
+  prometheus:
     enable_prom_sink: "true"
     new_prometheus:
       create_prometheus: "false"


### PR DESCRIPTION
Hello everyone,

First and foremost, thank you for your incredible work on this project! I appreciate the effort that has gone into it.

Please consider this as a preliminary draft. I encountered some challenges while attempting to deploy pgwatch without PostgreSQL as a sink. My goal was to set up pgwatch to monitor existing PostgreSQL databases while utilizing an existing Prometheus instance.

Once this PR is ready for merging, I plan to submit another PR that will introduce optional alert rules and service monitors. This will enable deployment within an existing monitoring setup that uses the Prometheus operator.

### Key Changes:

- **Multiple Source Definitions:** Added the ability to define multiple sources through the values file.
- **Prometheus-Only Deployment:** Resolved the issue preventing deployment of the exporter with only Prometheus as a sink by verifying the existence of a database definition.
- **Grafana Service Binding:** The Grafana service is now conditionally bound to the deployment of Grafana.
- **Prometheus Metrics Port:** The port for Prometheus metrics is now utilized if Prometheus is created or if the Prometheus sink is enabled.

Thank you for considering this PR. I look forward to your feedback!