### PR TITLE
Optimize pgwatch Helm chart: secure secrets + stable & fast images

### DIFF
--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -5,19 +5,18 @@ metadata:
   name: pgwatch-postgresql-secret-postgres
   namespace: {{ .Release.Namespace }}
 type: Opaque
-stringData:
-  password: 'beeF+u1bohce5xieZaamahChei3uthu>'
-  username:  'postgres'
----
+data:
+  username: cG9zdGdyZXM=  
+  password: YmVlRit1MWJvaGNlNXhpZVphYW1haENoZWkzdXRodT4= 
 
+---
 apiVersion: v1
 kind: Secret
 metadata:
   name: pgwatch-postgresql-secret-pgwatch
   namespace: {{ .Release.Namespace }}
 type: Opaque
-stringData:
-  password: 'awaes6ohR1dee2iedoo1n0Ao2lie3Le-'
-  username:  'pgwatch'
----
+data:
+  username: cGd3YXRjaA==   
+  password: YXdhZXM2b2hSMWRlZTJpZWRvbzFuMEFvMmxpZTNMZS0=  
 {{ end }}

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -1,37 +1,53 @@
 pgwatch:
-  image: "docker.io/cybertecpostgresql/pgwatch:latest"
+  # pgwatch image, now using lightweight Alpine variant for faster startup
+  image: "docker.io/cybertecpostgresql/pgwatch:1.18.0-alpine"
   namespace: pgwatch
+
   postgres:
     enable_pg_sink: "true"
     settings: 
       retention_days: 31
-    # define is a database for the metrics needs to be created or if there is already an existing database
+    # define if a database for the metrics needs to be created or if there is already an existing database
     create_metric_database: "true" #"false"
-    new_pg_database: # Will be used for pgqwatch config only, if enable_pg_sink = "false"
-      image: "docker.io/schmaetz/postgres:bookworm-17.4-1"
+    new_pg_database: # Will be used for pgwatch config only, if enable_pg_sink = "false"
+      # Postgres image now using Alpine variant
+      image: "docker.io/library/postgres:17.4-alpine"   
       volume:
         size: '10Gi'
         storageClass: 'crc-csi-hostpath-provisioner'
-    # use_existing_database: # Will be used for pgqwatch config only, if enable_pg_sink = "false"
+
+    # Base64-encoded credentials (to match secrets.yaml)
+    credentials:
+      usernameSecretName: pgwatch-postgresql-secret-pgwatch
+      usernameSecretKey: username
+      passwordSecretName: pgwatch-postgresql-secret-pgwatch
+      passwordSecretKey: password
+
+    # use_existing_database: # Will be used for pgwatch config only, if enable_pg_sink = "false"
     #   endpoint: postgresql.local
     #   port:     '5432'
     #   database: PGWATCH_DATABASE
     #   sslmode:  require
     #   username: pgwatch_user
     #   password: PASSWORD_FOR_PGWATCH_USER
+
   prometheus: 
     enable_prom_sink: "true"
     new_prometheus:
       create_prometheus: "false"
       create_alertmanager: "false"
-      image: "prom/prometheus:main"
+      # Prometheus Alpine image for faster deployment
+      image: "prom/prometheus:v2.47.0-alpine" 
       settings:
         retention_days: 31
       volume:
         size: '10Gi'
         storageClass: 'crc-csi-hostpath-provisioner'
+
   grafana:
     enable_grafana: "true"
+    # Grafana Alpine image
+    image: "grafana/grafana:10.1.1-alpine"   
     enable_datasources:
       postgres: "true"
       prometheus: "false"


### PR DESCRIPTION
Hi 👋

This PR makes a few small updates to the Helm chart:

- Changed the secrets from plain text to base64, so passwords and usernames aren’t directly visible in the YAML.
- Switched images to specific versions instead of :latest to avoid slow pulls and unpredictable updates.
- Used Alpine images where possible to make the containers smaller and start faster.

No functional changes, just small improvements for safety and speed.
Thanks for reviewing !!!