### PR TITLE
Use native booleans in Helm chart values

### DIFF
--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -47,6 +47,10 @@ helm upgrade pgwatch -n pgwatch -f custom-values.yaml .
 
 The Helm chart currently supports PostgreSQL and Prometheus as a sink. This can be controlled via the [values](https://github.com/cybertec-postgresql/pgwatch-charts/blob/pgwatch-3-helm-chart/helm/pgwatch/values.yaml) file.
 
+Boolean options in this chart now use native YAML booleans (`true` / `false`).
+Legacy string values (`"true"` / `"false"`) are still accepted temporarily for
+compatibility, but are deprecated and will be removed in a future chart version.
+
 - PostgreSQL
   - Use an existing configuration and metric database
   - Create a new PostgreSQL instance in the same namespace

--- a/helm/pgwatch/templates/NOTES.txt
+++ b/helm/pgwatch/templates/NOTES.txt
@@ -1,0 +1,20 @@
+{{- if include "pgwatch.hasLegacyBoolValues" . }}
+WARNING:
+Detected legacy string boolean values ("true"/"false") in pgwatch chart values.
+
+This compatibility behavior is deprecated and will be removed in the next chart
+version. Please update your values files and overrides to use native YAML
+booleans instead:
+
+  true
+  false
+
+Affected settings include:
+  - pgwatch.postgres.enable_pg_sink
+  - pgwatch.postgres.create_metric_database
+  - pgwatch.prometheus.enable_prom_sink
+  - pgwatch.prometheus.new_prometheus.create_prometheus
+  - pgwatch.grafana.enable_grafana
+  - pgwatch.grafana.enable_datasources.postgres
+  - pgwatch.grafana.enable_datasources.prometheus
+{{- end }}

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -99,3 +99,60 @@ pgwatch.dbHost
 postgres-svc
 {{- end -}}
 {{- end }}
+
+{{/*
+pgwatch.isTrue
+  Returns the string "true" when the input is either the native boolean true
+  or the legacy string value "true". Returns an empty string otherwise.
+
+  Usage:
+    {{- if include "pgwatch.isTrue" .Values.some.path }}
+*/}}
+{{- define "pgwatch.isTrue" -}}
+{{- $v := . -}}
+{{- if kindIs "bool" $v -}}
+  {{- if $v -}}
+true
+  {{- end -}}
+{{- else if eq (toString $v) "true" -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+pgwatch.isLegacyBoolString
+  Returns the string "true" when the input is a legacy string boolean
+  ("true" or "false"). Returns an empty string otherwise.
+*/}}
+{{- define "pgwatch.isLegacyBoolString" -}}
+{{- $v := . -}}
+{{- if and (kindIs "string" $v) (or (eq $v "true") (eq $v "false")) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+pgwatch.hasLegacyBoolValues
+  Returns the string "true" when any supported boolean value is still passed as
+  a legacy string ("true" / "false"). Used for deprecation notices.
+*/}}
+{{- define "pgwatch.hasLegacyBoolValues" -}}
+{{- $values := list
+  .Values.pgwatch.postgres.enable_pg_sink
+  .Values.pgwatch.postgres.create_metric_database
+  .Values.pgwatch.prometheus.enable_prom_sink
+  .Values.pgwatch.prometheus.new_prometheus.create_prometheus
+  .Values.pgwatch.grafana.enable_grafana
+  .Values.pgwatch.grafana.enable_datasources.postgres
+  .Values.pgwatch.grafana.enable_datasources.prometheus
+-}}
+{{- $state := dict "hasLegacy" false -}}
+{{- range $values -}}
+  {{- if include "pgwatch.isLegacyBoolString" . -}}
+    {{- $_ := set $state "hasLegacy" true -}}
+  {{- end -}}
+{{- end -}}
+{{- if $state.hasLegacy -}}
+true
+{{- end -}}
+{{- end }}

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -20,7 +20,7 @@
     - Secret pgwatch-postgresql-secret-pgwatch  keys username / password
 ==============================================================================
 */}}
-{{- if or .Values.timescaledb.enabled (eq .Values.pgwatch.postgres.create_metric_database "true") }}
+{{- if or .Values.timescaledb.enabled (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm/pgwatch/templates/grafana-dashboard-config.yaml
+++ b/helm/pgwatch/templates/grafana-dashboard-config.yaml
@@ -3,7 +3,7 @@
   When useSubchart: true the official Grafana subchart sidecar discovers
   dashboards via the grafana_dashboard ConfigMap label — no provider file needed.
 */}}
-{{- if and (eq .Values.pgwatch.grafana.enable_grafana "true") (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,7 +15,7 @@ data:
   dashboards_provider.yml: |
     apiVersion: 1
     providers:
-    {{- if eq .Values.pgwatch.postgres.enable_pg_sink "true" }}
+    {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
     - name: 'pgwatch-postgres'
       orgId: 1
       folder: 'PostgreSQL'
@@ -23,7 +23,7 @@ data:
       options:
         path: /var/lib/grafana/dashboards/postgresql
     {{- end }}
-    {{- if eq .Values.pgwatch.prometheus.enable_prom_sink "true" }}
+    {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
     - name: 'pgwatch-prometheus'
       orgId: 1
       folder: 'Prometheus'

--- a/helm/pgwatch/templates/grafana-deployment.yaml
+++ b/helm/pgwatch/templates/grafana-deployment.yaml
@@ -2,7 +2,7 @@
   Skipped when pgwatch.grafana.useSubchart: true — the official Grafana subchart
   provides the Grafana instance in that case (see grafana: top-level values block).
 */}}
-{{- if and (eq .Values.pgwatch.grafana.enable_grafana "true") (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +36,7 @@ spec:
               value: /var/lib/grafana/dashboards/postgresql/1-global-db-overview.json
           #  - name: GF_INSTALL_PLUGINS
           #    value: marcusolsson-treemap-panel
-            {{- if eq .Values.pgwatch.postgres.create_metric_database "true" }}
+            {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
             - name: GF_DATABASE_TYPE
               value: postgres
             - name: GF_DATABASE_HOST
@@ -120,7 +120,7 @@ spec:
           projected:
             defaultMode: 416
             sources:
-              {{- if eq .Values.pgwatch.postgres.enable_pg_sink "true" }}
+              {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
               {{- range $path, $_ := .Files.Glob "dashboards/postgresql/*.json" }}
               - configMap:
                   name: "grafana-postgresql-dashboard-{{ base $path | lower | replace "." "-" | replace "_" "-" }}"
@@ -130,7 +130,7 @@ spec:
               {{- end }}
               {{- end }}
 
-              {{- if eq .Values.pgwatch.prometheus.enable_prom_sink "true" }}
+              {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
               {{- range $path, $_ := .Files.Glob "dashboards/prometheus/*.json" }}
               - configMap:
                   name: "grafana-prometheus-dashboard-{{ base $path | lower | replace "." "-" | replace "_" "-" }}"
@@ -154,7 +154,7 @@ spec:
     provisioning directory — no pod restart required.
 
 */}}
-{{- if eq .Values.pgwatch.grafana.enable_grafana "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -177,8 +177,8 @@ data:
   postgres_datasource.yml: |
     apiVersion: 1
     datasources:
-  {{- if eq .Values.pgwatch.grafana.enable_datasources.postgres "true" }}
-  {{- if eq .Values.pgwatch.postgres.create_metric_database "true" }}
+  {{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.postgres }}
+  {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
     - name: pgwatch-metrics
       type: postgres
       url: "{{ include "pgwatch.dbHost" . }}:5432"
@@ -210,7 +210,7 @@ data:
       editable: true
   {{ end }}
   {{ end }}
-  {{- if eq .Values.pgwatch.grafana.enable_datasources.prometheus "true" }}
+  {{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.prometheus }}
     - name: PROMETHEUS
       type: prometheus
       access: proxy
@@ -223,7 +223,7 @@ data:
       basicAuthUser:
       basicAuthPassword:
       withCredentials:
-      {{- if ne .Values.pgwatch.grafana.enable_datasources.postgres "true" }}
+      {{- if not (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.postgres) }}
       isDefault: true
       {{- end}}
       version: 1

--- a/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.postgres.enable_pg_sink "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
 {{- range $path, $_ := .Files.Glob "dashboards/postgresql/*.json" }}
 {{- $filename := base $path }}
 {{- $name := $filename | lower | replace "." "-" | replace "_" "-" }}

--- a/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.prometheus.enable_prom_sink "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
 {{- range $path, $_ := .Files.Glob "dashboards/prometheus/*.json" }}
 {{- $filename := base $path }}
 {{- $name := $filename | lower | replace "." "-" | replace "_" "-" }}

--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.securityContext) | nindent 6 }}
       containers:
         - env:
-        {{- if eq .Values.pgwatch.postgres.create_metric_database "true" }}
+        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
           - name: PGWATCH_USER
             valueFrom:
               secretKeyRef:
@@ -54,13 +54,13 @@ spec:
           - name: METRIC_DATABASE_SSLMODE
             value: {{ .Values.pgwatch.postgres.use_existing_database.sslmode }}
         {{ end }}
-        {{- if eq .Values.pgwatch.postgres.enable_pg_sink "true" }}
+        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
           - name: PG_IS_SINK
             value: "true"
           - name: PG_RETENTION_DAYS
             value: "{{ .Values.pgwatch.postgres.settings.retention_days }} days"
         {{ end }}
-        {{- if eq .Values.pgwatch.prometheus.enable_prom_sink "true" }}
+        {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
           - name: PROM_IS_SINK
             value: "true"
         {{ end }}
@@ -96,7 +96,7 @@ spec:
           ports:
             - containerPort: {{ .Values.pgwatch.webPort }}
               protocol: TCP
-        {{- if eq .Values.pgwatch.prometheus.enable_prom_sink "true" }}
+        {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
             - containerPort: 9188
               protocol: TCP
         {{ end }}

--- a/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
@@ -1,6 +1,6 @@
 # File to configure the Alertmanager
 # This file is part of the CPO monitoring stack from CYBERTEC PostgreSQL International GmbH.
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/pgwatch/templates/postgres-statefulset.yaml
+++ b/helm/pgwatch/templates/postgres-statefulset.yaml
@@ -2,7 +2,7 @@
   Skipped when timescaledb.enabled: true — the TimescaleDB subchart provides the
   database in that case and db-init-job.yaml handles schema/user bootstrapping.
 */}}
-{{- if and (eq .Values.pgwatch.postgres.create_metric_database "true") (not .Values.timescaledb.enabled) }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) (not .Values.timescaledb.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/helm/pgwatch/templates/prometheus-config.yaml
+++ b/helm/pgwatch/templates/prometheus-config.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/pgwatch/templates/prometheus-deployment.yaml
+++ b/helm/pgwatch/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/pgwatch/templates/pvcs.yaml
+++ b/helm/pgwatch/templates/pvcs.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.pgwatch.postgres.create_metric_database "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
 
 {{/*
   pgwatch-postgresql-secret-postgres — admin (superuser) credentials.
@@ -23,7 +23,7 @@ stringData:
   pgwatch-postgresql-secret-pgwatch — application user credentials.
   Referenced by the db-init-job and the pgwatch / Grafana containers to
   connect to the metrics database (StatefulSet or TimescaleDB).
-  Not created when an external database is used (create_metric_database: "false").
+  Not created when an external database is used (create_metric_database: false).
 */}}
 apiVersion: v1
 kind: Secret

--- a/helm/pgwatch/templates/services.yaml
+++ b/helm/pgwatch/templates/services.yaml
@@ -10,7 +10,7 @@ spec:
     - name: pgwatch
       port: {{ .Values.pgwatch.webPort }}
       targetPort: {{ .Values.pgwatch.webPort }}
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
     - name: pgwatch-prometheus-sink
       port: 9188
       targetPort: 9188
@@ -23,7 +23,7 @@ spec:
   grafana-svc is only needed for the custom Grafana Deployment.
   When useSubchart: true the official Grafana subchart creates its own Service.
 */}}
-{{- if and (eq .Values.pgwatch.grafana.enable_grafana "true") (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,7 +45,7 @@ spec:
   postgres-svc is only needed for the built-in PostgreSQL StatefulSet.
   When timescaledb.enabled: true the TimescaleDB subchart creates its own Service.
 */}}
-{{- if and (eq .Values.pgwatch.postgres.create_metric_database "true") (not .Values.timescaledb.enabled) }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) (not .Values.timescaledb.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -63,7 +63,7 @@ spec:
     pgwatch.pods.role: postgres
 {{ end }}
 ---
-{{- if eq .Values.pgwatch.prometheus.new_prometheus.create_prometheus "true" }}
+{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -117,22 +117,22 @@ pgwatch:
   # == Metrics sink: PostgreSQL ==
 
   postgres:
-    enable_pg_sink: "true"
+    enable_pg_sink: true
     settings:
       retention_days: 31
 
-    # -- Set to "true" to deploy a new PostgreSQL StatefulSet (default).
-    # -- Set to "false" and configure use_existing_database below to connect to an existing instance.
-    create_metric_database: "true"
+    # -- Set to true to deploy a new PostgreSQL StatefulSet (default).
+    # -- Set to false and configure use_existing_database below to connect to an existing instance.
+    create_metric_database: true
 
-    # -- New PostgreSQL instance — active when create_metric_database: "true".
+    # -- New PostgreSQL instance — active when create_metric_database: true.
     new_pg_database:
       image: "docker.io/postgres:18.3-alpine3.23"
       volume:
         size: '10Gi'
         storageClass: 'standard'
 
-    # -- Existing PostgreSQL instance — active when create_metric_database: "false".
+    # -- Existing PostgreSQL instance — active when create_metric_database: false.
     # use_existing_database:
     #   endpoint: postgresql.local
     #   port:     '5432'
@@ -161,11 +161,11 @@ pgwatch:
   # == Metrics sink: Prometheus ==
 
   prometheus:
-    enable_prom_sink: "true"
+    enable_prom_sink: true
 
-    # -- New Prometheus instance — active when create_prometheus: "true".
+    # -- New Prometheus instance — active when create_prometheus: true.
     new_prometheus:
-      create_prometheus: "true"
+      create_prometheus: true
       image: "prom/prometheus:main"
       settings:
         retention_days: 31
@@ -173,7 +173,7 @@ pgwatch:
         size: '10Gi'
         storageClass: 'standard'
 
-    # -- Existing Prometheus instance — active when create_prometheus: "false".
+    # -- Existing Prometheus instance — active when create_prometheus: false.
     #
     # TODO: Implement use_existing_prometheus
     #
@@ -212,13 +212,13 @@ pgwatch:
     # When false (default): the custom Deployment runs exactly as before.
     useSubchart: false
     image: grafana/grafana:12.4.0-21419697389 # Dashboards are prepared for grafana v12
-    enable_grafana: "true"
+    enable_grafana: true
     # -- Controls which Grafana datasources are provisioned.
     # Independent of the sink settings (enable_pg_sink / enable_prom_sink), which control
     # what pgwatch writes to. These control what Grafana is configured to query.
     enable_datasources:
-      postgres: "true"
-      prometheus: "true"
+      postgres: true
+      prometheus: true
 
     # -- Component-specific overrides for the Grafana Deployment.
     # The official Grafana image runs as UID/GID 472.


### PR DESCRIPTION
* Replace quoted boolean-like defaults in values.yaml with native YAML booleans
* Update templates to use compatibility-aware boolean checks
* Add NOTES.txt warning for deprecated string boolean values
* Document native boolean usage and temporary compatibility in README

Fixes #13. 

An example of the warning:
```
Release "pgwatch" has been upgraded. Happy Helming!
NAME: pgwatch
LAST DEPLOYED: Fri Apr 24 12:03:45 2026
NAMESPACE: pgwatch
STATUS: deployed
REVISION: 6
TEST SUITE: None
NOTES:
WARNING:
Detected legacy string boolean values ("true"/"false") in pgwatch chart values.

This compatibility behavior is deprecated and will be removed in the next chart
version. Please update your values files and overrides to use native YAML
booleans instead:

true
false

Affected settings include:
- pgwatch.postgres.enable_pg_sink
- pgwatch.postgres.create_metric_database
- pgwatch.prometheus.enable_prom_sink
- pgwatch.prometheus.new_prometheus.create_prometheus
- pgwatch.grafana.enable_grafana
- pgwatch.grafana.enable_datasources.postgres
- pgwatch.grafana.enable_datasources.prometheus
```

Please review