### PR TITLE
Implement secret-backed DB credentials

### DIFF
--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -56,13 +56,119 @@ compatibility, but are deprecated and will be removed in a future chart version.
   - Create a new PostgreSQL instance in the same namespace
   - Optionally replace with **TimescaleDB** (see [Helm Dependencies](#helm-dependencies))
 - Prometheus
-  - Use an existing Prometheus as sink (enables sink on port 9188)
   - Create a new Prometheus instance in the same namespace
+  - External Prometheus support: planned (not yet implemented)
 - Grafana
   - Deploy Grafana with dashboards for both PostgreSQL and Prometheus sinks
   - Optionally use the official Grafana Helm subchart (see [Helm Dependencies](#helm-dependencies))
 
 ## Advanced Customisation
+
+### Credential Management
+
+[Issue #12](https://github.com/cybertec-postgresql/pgwatch-charts/issues/12) changed credential handling to use Kubernetes Secrets instead of
+hardcoded values or plaintext in manifests.
+
+**Deprecation:** `use_existing_database.username/password` still work but will emit warnings. They will be removed in a future chart version.
+
+#### Precedence
+
+For the pgwatch application / Grafana DB user credentials under
+`pgwatch.postgres.credentials` the chart uses this order:
+
+1. `credentials.existingSecret` — chart creates no Secret
+2. `credentials.username` / `credentials.password` — chart creates Secret
+3. DEPRECATED: `use_existing_database.username` / `password` — fallback, emits warning
+
+#### Generated Secrets
+
+When not using `existingSecret`, the chart creates these default Secrets from the provided values:
+
+- **`pgwatch-postgresql-secret-pgwatch`** — application user credentials (username, password)
+  - Used by db-init-job, pgwatch, and Grafana to connect to the metrics database
+- **`pgwatch-postgresql-secret-postgres`** — admin credentials (username: postgres, password)
+  - Only created for built-in PostgreSQL (not for TimescaleDB or external databases)
+
+#### 1. Built-in PostgreSQL
+
+```yaml
+pgwatch:
+  postgres:
+    create_metric_database: true
+    credentials:
+      username: pgwatch
+      password: change-me-app
+    adminCredentials:
+      password: change-me-admin  # ignored for TimescaleDB/external
+```
+
+#### 2. External PostgreSQL
+
+```yaml
+pgwatch:
+  postgres:
+    create_metric_database: false
+    use_existing_database:
+      endpoint: postgresql.local
+      port: "5432"
+      database: pgwatch_metrics
+      sslmode: require
+    credentials:
+      username: pgwatch_user
+      password: change-me
+```
+
+#### 3. External PostgreSQL with existing Secret
+
+```yaml
+pgwatch:
+  postgres:
+    create_metric_database: false
+    use_existing_database:
+      endpoint: postgresql.local
+      port: "5432"
+      database: pgwatch_metrics
+      sslmode: require
+    credentials:
+      existingSecret: pgwatch-external-db
+      usernameKey: username
+      passwordKey: password
+```
+
+#### Migrating from deprecated inline credentials
+
+Before (deprecated, still works with warning):
+
+```yaml
+pgwatch:
+  postgres:
+    use_existing_database:
+      endpoint: postgresql.local
+      username: pgwatch_user   # deprecated
+      password: change-me      # deprecated
+```
+
+After:
+
+```yaml
+pgwatch:
+  postgres:
+    use_existing_database:
+      endpoint: postgresql.local
+    credentials:
+      username: pgwatch_user
+      password: change-me
+```
+
+#### Grafana subchart note
+
+When `pgwatch.grafana.useSubchart=true`, the datasource ConfigMap still uses
+`${PGWATCH_METRICS_DS_USER}` / `${PGWATCH_METRICS_DS_PASSWORD}` placeholders.
+If you use a pre-existing Secret with custom key names, mirror those values
+into the Grafana subchart via top-level `grafana.envValueFrom` so the Grafana
+container can resolve the placeholders.
+
+### Environment Variables and Config Injection
 
 Every component (`pgwatch`, `postgres`, `prometheus`, `grafana`) exposes two additional extension points:
 
@@ -86,7 +192,9 @@ Every component (`pgwatch`, `postgres`, `prometheus`, `grafana`) exposes two add
           name: my-pgwatch-secret
   ```
 
-**Security contexts** can be tuned at two levels:
+### Security Contexts
+
+Security contexts can be tuned at two levels:
 
 - **Global baseline** (`securityContext.enabled: true`) - applies a shared pod- and container-level security context to all components. Per-component values are merged on top and always win.
 - **Per-component overrides** - each component exposes its own `securityContext.pod` / `securityContext.container` keys, applied independently when the global baseline is disabled (the default).
@@ -108,9 +216,11 @@ Every component (`pgwatch`, `postgres`, `prometheus`, `grafana`) exposes two add
         allowPrivilegeEscalation: false
   ```
 
-> See the [Local development (Minikube)](#local-development-minikube) section for a concrete example of overriding security contexts when `fsGroup` is not applied by the cluster.
+> See the [Local Development (Minikube)](#local-development-minikube) section for a concrete example of overriding security contexts when `fsGroup` is not applied by the cluster.
 
-**`extraDeploy`** allows you to deploy arbitrary Kubernetes resources alongside the chart (e.g. `ServiceMonitor`, additional `ConfigMap`, CRDs). Each entry is rendered via `tpl`, so Helm template expressions are supported.
+### Extra Resources
+
+`extraDeploy` allows you to deploy arbitrary Kubernetes resources alongside the chart (e.g. `ServiceMonitor`, additional `ConfigMap`, CRDs). Each entry is rendered via `tpl`, so Helm template expressions are supported.
 
 > !! No validation is performed on `extraDeploy` entries. Users are responsible for the correctness of the resources they provide.
 
@@ -138,6 +248,8 @@ Both subcharts are **opt-in** and disabled by default. Run `helm dependency upda
 
 Replaces the built-in PostgreSQL StatefulSet with a TimescaleDB instance.
 Chart: `cloudpirates/timescaledb` `0.10.4` - [ArtifactHub](https://artifacthub.io/packages/helm/cloudpirates-timescaledb/timescaledb)
+
+**Note:** `pgwatch.postgres.adminCredentials` has no effect when TimescaleDB is enabled. Use `timescaledb.auth.*` instead.
 
 ```yaml
 timescaledb:
@@ -182,7 +294,7 @@ grafana:
 
 ---
 
-## Local development (Minikube)
+## Local Development (Minikube)
 
 The `postgres` and `timescaledb` images are designed to start as root, set up the data directory, and then drop to the postgres user (uid 999). The chart defaults leave the security context empty so clusters that properly apply `fsGroup` volume ownership can run those images as non-root.
 

--- a/helm/pgwatch/templates/NOTES.txt
+++ b/helm/pgwatch/templates/NOTES.txt
@@ -18,3 +18,28 @@ Affected settings include:
   - pgwatch.grafana.enable_datasources.postgres
   - pgwatch.grafana.enable_datasources.prometheus
 {{- end }}
+
+{{- if include "pgwatch.hasLegacyExternalDbInlineCredentials" . }}
+WARNING:
+Detected deprecated inline external database credentials under:
+
+  pgwatch.postgres.use_existing_database.username
+  pgwatch.postgres.use_existing_database.password
+
+Please migrate to one of the new secret-backed options:
+  - pgwatch.postgres.credentials.username / password
+  - pgwatch.postgres.credentials.existingSecret
+{{- end }}
+
+{{- if or (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+          .Values.pgwatch.postgres.use_existing_database }}
+
+Credential Secret:
+  kubectl get secret {{ include "pgwatch.credentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
+{{- end }}
+
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+          (not .Values.timescaledb.enabled) }}
+Postgres Admin Secret:
+  kubectl get secret {{ include "pgwatch.adminCredentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
+{{- end }}

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -156,3 +156,59 @@ pgwatch.hasLegacyBoolValues
 true
 {{- end -}}
 {{- end }}
+
+{{/*
+pgwatch.credentialSecretName
+  Name of the Secret that stores the pgwatch application user credentials.
+*/}}
+{{- define "pgwatch.credentialSecretName" -}}
+{{- (.Values.pgwatch.postgres.credentials | default dict).existingSecret
+    | default "pgwatch-postgresql-secret-pgwatch" -}}
+{{- end }}
+
+{{/*
+pgwatch.credentialUsernameKey
+  Key containing the pgwatch username in the credential secret.
+*/}}
+{{- define "pgwatch.credentialUsernameKey" -}}
+{{- (.Values.pgwatch.postgres.credentials | default dict).usernameKey
+    | default "username" -}}
+{{- end }}
+
+{{/*
+pgwatch.credentialPasswordKey
+  Key containing the pgwatch password in the credential secret.
+*/}}
+{{- define "pgwatch.credentialPasswordKey" -}}
+{{- (.Values.pgwatch.postgres.credentials | default dict).passwordKey
+    | default "password" -}}
+{{- end }}
+
+{{/*
+pgwatch.adminCredentialSecretName
+  Name of the Secret that stores the built-in postgres admin credentials.
+*/}}
+{{- define "pgwatch.adminCredentialSecretName" -}}
+{{- (.Values.pgwatch.postgres.adminCredentials | default dict).existingSecret
+    | default "pgwatch-postgresql-secret-postgres" -}}
+{{- end }}
+
+{{/*
+pgwatch.adminCredentialPasswordKey
+  Key containing the built-in postgres admin password.
+*/}}
+{{- define "pgwatch.adminCredentialPasswordKey" -}}
+{{- (.Values.pgwatch.postgres.adminCredentials | default dict).passwordKey
+    | default "password" -}}
+{{- end }}
+
+{{/*
+pgwatch.hasLegacyExternalDbInlineCredentials
+  True when deprecated external DB username/password fields are still used.
+*/}}
+{{- define "pgwatch.hasLegacyExternalDbInlineCredentials" -}}
+{{- $existingDb := .Values.pgwatch.postgres.use_existing_database | default dict -}}
+{{- if or $existingDb.username $existingDb.password -}}
+true
+{{- end -}}
+{{- end }}

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -16,8 +16,9 @@
     - TimescaleDB, existingSecret    : Secret timescaledb.auth.existingSecret  key postgres-password
     - Plain postgres                 : Secret pgwatch-postgresql-secret-postgres  key password
 
-  The pgwatch user credentials are always read from:
-    - Secret pgwatch-postgresql-secret-pgwatch  keys username / password
+  The pgwatch user credentials are sourced from:
+    - credentials.existingSecret (if set)
+    - OR Secret pgwatch-postgresql-secret-pgwatch  keys username / password (default)
 ==============================================================================
 */}}
 {{- if or .Values.timescaledb.enabled (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) }}
@@ -58,19 +59,19 @@ spec:
                   name: {{ .Values.timescaledb.auth.existingSecret | default (printf "%s-timescaledb" .Release.Name) }}
                   key: postgres-password
                   {{- else }}
-                  name: pgwatch-postgresql-secret-postgres
-                  key: password
+                  name: {{ include "pgwatch.adminCredentialSecretName" . }}
+                  key: {{ include "pgwatch.adminCredentialPasswordKey" . }}
                   {{- end }}
             - name: PGWATCH_USER
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: username
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialUsernameKey" . }}
             - name: PGWATCH_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: password
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialPasswordKey" . }}
           command:
             - /bin/sh
             - -c

--- a/helm/pgwatch/templates/grafana-deployment.yaml
+++ b/helm/pgwatch/templates/grafana-deployment.yaml
@@ -48,24 +48,24 @@ spec:
             - name: GF_DATABASE_USER
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: username
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialUsernameKey" . }}
             - name: GF_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: password
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialPasswordKey" . }}
             # Separate credentials for the pgwatch-metrics datasource.
             - name: PGWATCH_METRICS_DS_USER
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: username
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialUsernameKey" . }}
             - name: PGWATCH_METRICS_DS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: pgwatch-postgresql-secret-pgwatch
-                  key: password
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialPasswordKey" . }}
             {{- else if .Values.pgwatch.postgres.use_existing_database }}
             - name: GF_DATABASE_TYPE
               value: postgres
@@ -78,9 +78,25 @@ spec:
             - name: GF_DATABASE_SSL_MODE
               value: {{ .Values.pgwatch.postgres.use_existing_database.sslmode }}
             - name: GF_DATABASE_USER
-              value: {{ .Values.pgwatch.postgres.use_existing_database.username }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialUsernameKey" . }}
             - name: GF_DATABASE_PASSWORD
-              value: {{ .Values.pgwatch.postgres.use_existing_database.password }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialPasswordKey" . }}
+            - name: PGWATCH_METRICS_DS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialUsernameKey" . }}
+            - name: PGWATCH_METRICS_DS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "pgwatch.credentialSecretName" . }}
+                  key: {{ include "pgwatch.credentialPasswordKey" . }}
             {{- end }}
             {{- range $key, $value := .Values.pgwatch.grafana.env }}
             - name: {{ $key }}
@@ -199,13 +215,13 @@ data:
       type: postgres
       url: {{ .Values.pgwatch.postgres.use_existing_database.endpoint }}:{{ .Values.pgwatch.postgres.use_existing_database.port }}
       access: proxy
-      user: {{ .Values.pgwatch.postgres.use_existing_database.username }}
+      user: "${PGWATCH_METRICS_DS_USER}"
       isDefault: true
       jsonData:
         database: {{ .Values.pgwatch.postgres.use_existing_database.database }}
         sslmode: {{ .Values.pgwatch.postgres.use_existing_database.sslmode | default "disable" }}
       secureJsonData:
-        password: {{ .Values.pgwatch.postgres.use_existing_database.password }}
+        password: "${PGWATCH_METRICS_DS_PASSWORD}"
       version: 1
       editable: true
   {{ end }}

--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -21,17 +21,17 @@ spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.securityContext) | nindent 6 }}
       containers:
         - env:
-        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
           - name: PGWATCH_USER
             valueFrom:
               secretKeyRef:
-                name: pgwatch-postgresql-secret-pgwatch
-                key: username
+                name: {{ include "pgwatch.credentialSecretName" . }}
+                key: {{ include "pgwatch.credentialUsernameKey" . }}
           - name: PGWATCH_USER_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: pgwatch-postgresql-secret-pgwatch
-                key: password
+                name: {{ include "pgwatch.credentialSecretName" . }}
+                key: {{ include "pgwatch.credentialPasswordKey" . }}
+        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
           - name: METRIC_DATABASE_ENDPOINT
             value: "{{ include "pgwatch.dbHost" . }}.{{ .Release.Namespace }}.svc.cluster.local"
           - name: METRIC_DATABASE_PORT
@@ -41,10 +41,6 @@ spec:
           - name: METRIC_DATABASE_SSLMODE
             value: disable
         {{- else if .Values.pgwatch.postgres.use_existing_database }}
-          - name: PGWATCH_USER
-            value: {{ .Values.pgwatch.postgres.use_existing_database.username }}
-          - name: PGWATCH_USER_PASSWORD
-            value: {{ .Values.pgwatch.postgres.use_existing_database.password }}
           - name: METRIC_DATABASE_ENDPOINT
             value: {{ .Values.pgwatch.postgres.use_existing_database.endpoint }}
           - name: METRIC_DATABASE_PORT

--- a/helm/pgwatch/templates/postgres-statefulset.yaml
+++ b/helm/pgwatch/templates/postgres-statefulset.yaml
@@ -58,8 +58,8 @@ spec:
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: pgwatch-postgresql-secret-postgres
-              key: password
+              name: {{ include "pgwatch.adminCredentialSecretName" . }}
+              key: {{ include "pgwatch.adminCredentialPasswordKey" . }}
         - name: POSTGRES_USER
           value: postgres
         - name: PGDATA

--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -1,4 +1,17 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
+{{- if or (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+          .Values.pgwatch.postgres.use_existing_database }}
+
+{{/*
+  Credential resolution via coalesce (first non-empty value wins):
+  1. credentials.{username,password} (new)
+  2. use_existing_database.{username,password} (legacy, deprecated)
+  3. "pgwatch" (default username only)
+*/}}
+{{- $creds      := .Values.pgwatch.postgres.credentials      | default dict -}}
+{{- $adminCreds := .Values.pgwatch.postgres.adminCredentials | default dict -}}
+{{- $existingDb := .Values.pgwatch.postgres.use_existing_database | default dict -}}
+{{- $pgwatchUsername := coalesce $creds.username $existingDb.username "pgwatch" -}}
+{{- $pgwatchPassword := coalesce $creds.password $existingDb.password -}}
 
 {{/*
   pgwatch-postgresql-secret-postgres — admin (superuser) credentials.
@@ -6,7 +19,9 @@
   When timescaledb.enabled: true the TimescaleDB subchart manages its own
   admin secret and this one is not created.
 */}}
-{{- if not .Values.timescaledb.enabled }}
+{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+          (not .Values.timescaledb.enabled)
+          (not $adminCreds.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,7 +29,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  password: 'beeF+u1bohce5xieZaamahChei3uthu>'
+  password: {{ required
+      "Please set pgwatch.postgres.adminCredentials.password"
+      $adminCreds.password | quote }}
   username:  'postgres'
 ---
 {{- end }}
@@ -23,8 +40,9 @@ stringData:
   pgwatch-postgresql-secret-pgwatch — application user credentials.
   Referenced by the db-init-job and the pgwatch / Grafana containers to
   connect to the metrics database (StatefulSet or TimescaleDB).
-  Not created when an external database is used (create_metric_database: false).
+  Not created when credentials.existingSecret is set.
 */}}
+{{- if not $creds.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -32,7 +50,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:
-  password: 'awaes6ohR1dee2iedoo1n0Ao2lie3Le-'
-  username:  'pgwatch'
+  password: {{ required
+      "Please set pgwatch.postgres.credentials.password"
+      $pgwatchPassword | quote }}
+  username:  {{ $pgwatchUsername | quote }}
+{{- end }}
 
 {{- end }}

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -122,9 +122,7 @@ pgwatch:
       retention_days: 31
 
     # -- Set to true to deploy a new PostgreSQL StatefulSet (default).
-    # -- Set to false and configure use_existing_database below to connect to an existing instance.
     create_metric_database: true
-
     # -- New PostgreSQL instance — active when create_metric_database: true.
     new_pg_database:
       image: "docker.io/postgres:18.3-alpine3.23"
@@ -132,14 +130,44 @@ pgwatch:
         size: '10Gi'
         storageClass: 'standard'
 
-    # -- Existing PostgreSQL instance — active when create_metric_database: false.
+    # -- External database connection (active when create_metric_database: false).
+    # Set credentials via credentials.* below; username/password here are deprecated.
     # use_existing_database:
     #   endpoint: postgresql.local
     #   port:     '5432'
     #   database: PGWATCH_DATABASE
     #   sslmode:  require
-    #   username: pgwatch_user
-    #   password: PASSWORD_FOR_PGWATCH_USER
+    #   # username: # DEPRECATED, use credentials.username
+    #   # password: # DEPRECATED, use credentials.password
+
+    # -- Credentials for pgwatch and Grafana to connect to the metrics database.
+    #
+    # Precedence:
+    #   1. credentials.existingSecret — chart creates no Secret; keys read via usernameKey/passwordKey
+    #   2. credentials.username / password — chart creates pgwatch-postgresql-secret-pgwatch
+    #   3. DEPRECATED: use_existing_database.username / password — still works, emits warning
+    credentials:
+      # -- Name of an existing Secret that contains the pgwatch username/password.
+      # When set, the chart will not create pgwatch-postgresql-secret-pgwatch.
+      existingSecret: ""
+      username: "pgwatch"
+      password: ""
+      # -- Secret key containing the username when existingSecret is used.
+      usernameKey: "username"
+      # -- Secret key containing the password when existingSecret is used.
+      passwordKey: "password"
+
+    # -- Admin password for the built-in PostgreSQL StatefulSet.
+    # Only applies when create_metric_database: true and timescaledb.enabled: false.
+    # Has no effect for external databases or TimescaleDB subchart.
+    adminCredentials:
+      # -- Password for the postgres superuser stored in the admin Secret.
+      password: ""
+      # -- Name of an existing Secret that contains the postgres admin password.
+      # When set, the chart will not create pgwatch-postgresql-secret-postgres.
+      existingSecret: ""
+      # -- Secret key containing the postgres admin password.
+      passwordKey: "password"
 
     # -- Component-specific overrides for the PostgreSQL StatefulSet.
     securityContext:
@@ -298,3 +326,9 @@ grafana:
       org_role: Admin
     dashboards:
       default_home_dashboard_path: /tmp/dashboards/postgresql/1-global-db-overview.json
+  # -- Optional env vars injected into the Grafana subchart main container.
+  # When pgwatch.grafana.useSubchart=true and datasource credentials come from an
+  # existing Secret with custom keys, mirror those keys here via envValueFrom so
+  # Grafana can resolve ${PGWATCH_METRICS_DS_USER} / ${PGWATCH_METRICS_DS_PASSWORD}
+  # placeholders from the datasource ConfigMap.
+  envValueFrom: {}


### PR DESCRIPTION
- Add configurable pgwatch and postgres admin credential Secrets
- Support existing Secrets and custom secret keys in templates
- Deprecate inline external DB username/password with NOTES warning
- Document credential precedence and migration steps

Fixes #12. Please review. 