### PR TITLE
Standardize Helm values keys to camelCase

### DIFF
--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -51,6 +51,26 @@ Boolean options in this chart now use native YAML booleans (`true` / `false`).
 Legacy string values (`"true"` / `"false"`) are still accepted temporarily for
 compatibility, but are deprecated and will be removed in a future chart version.
 
+Values keys follow Helm's camelCase naming convention. The former snake_case
+keys are still accepted as backward-compatible fallbacks and emit a Helm
+install/upgrade warning. Please migrate them before the next major chart
+version, where snake_case compatibility will be removed:
+
+| Deprecated snake_case | Replacement camelCase |
+|---|---|
+| `pgwatch.postgres.enable_pg_sink` | `pgwatch.postgres.enablePgSink` |
+| `pgwatch.postgres.settings.retention_days` | `pgwatch.postgres.settings.retentionDays` |
+| `pgwatch.postgres.create_metric_database` | `pgwatch.postgres.createMetricDatabase` |
+| `pgwatch.postgres.new_pg_database` | `pgwatch.postgres.newPgDatabase` |
+| `pgwatch.postgres.use_existing_database` | `pgwatch.postgres.useExistingDatabase` |
+| `pgwatch.postgres.use_existing_database.grafana_database` | `pgwatch.postgres.useExistingDatabase.grafanaDatabase` |
+| `pgwatch.prometheus.enable_prom_sink` | `pgwatch.prometheus.enablePromSink` |
+| `pgwatch.prometheus.new_prometheus` | `pgwatch.prometheus.newPrometheus` |
+| `pgwatch.prometheus.new_prometheus.create_prometheus` | `pgwatch.prometheus.newPrometheus.createPrometheus` |
+| `pgwatch.prometheus.new_prometheus.settings.retention_days` | `pgwatch.prometheus.newPrometheus.settings.retentionDays` |
+| `pgwatch.grafana.enable_grafana` | `pgwatch.grafana.enableGrafana` |
+| `pgwatch.grafana.enable_datasources` | `pgwatch.grafana.enableDatasources` |
+
 - PostgreSQL
   - Use an existing configuration and metric database
   - Create a new PostgreSQL instance in the same namespace
@@ -69,7 +89,7 @@ compatibility, but are deprecated and will be removed in a future chart version.
 [Issue #12](https://github.com/cybertec-postgresql/pgwatch-charts/issues/12) changed credential handling to use Kubernetes Secrets instead of
 hardcoded values or plaintext in manifests.
 
-**Deprecation:** `use_existing_database.username/password` still work but will emit warnings. They will be removed in a future chart version.
+**Deprecation:** `useExistingDatabase.username/password` still work but will emit warnings. They will be removed in a future chart version.
 
 #### Precedence
 
@@ -78,7 +98,7 @@ For the pgwatch application / Grafana DB user credentials under
 
 1. `credentials.existingSecret` — chart creates no Secret
 2. `credentials.username` / `credentials.password` — chart creates Secret
-3. DEPRECATED: `use_existing_database.username` / `password` — fallback, emits warning
+3. DEPRECATED: `useExistingDatabase.username` / `password` — fallback, emits warning
 
 #### Generated Secrets
 
@@ -94,7 +114,7 @@ When not using `existingSecret`, the chart creates these default Secrets from th
 ```yaml
 pgwatch:
   postgres:
-    create_metric_database: true
+    createMetricDatabase: true
     credentials:
       username: pgwatch
       password: change-me-app
@@ -107,8 +127,8 @@ pgwatch:
 ```yaml
 pgwatch:
   postgres:
-    create_metric_database: false
-    use_existing_database:
+    createMetricDatabase: false
+    useExistingDatabase:
       endpoint: postgresql.local
       port: "5432"
       database: pgwatch_metrics
@@ -123,8 +143,8 @@ pgwatch:
 ```yaml
 pgwatch:
   postgres:
-    create_metric_database: false
-    use_existing_database:
+    createMetricDatabase: false
+    useExistingDatabase:
       endpoint: postgresql.local
       port: "5432"
       database: pgwatch_metrics
@@ -142,7 +162,7 @@ Before (deprecated, still works with warning):
 ```yaml
 pgwatch:
   postgres:
-    use_existing_database:
+    useExistingDatabase:
       endpoint: postgresql.local
       username: pgwatch_user   # deprecated
       password: change-me      # deprecated
@@ -153,7 +173,7 @@ After:
 ```yaml
 pgwatch:
   postgres:
-    use_existing_database:
+    useExistingDatabase:
       endpoint: postgresql.local
     credentials:
       username: pgwatch_user

--- a/helm/pgwatch/templates/NOTES.txt
+++ b/helm/pgwatch/templates/NOTES.txt
@@ -9,36 +9,62 @@ booleans instead:
   true
   false
 
-Affected settings include:
-  - pgwatch.postgres.enable_pg_sink
-  - pgwatch.postgres.create_metric_database
-  - pgwatch.prometheus.enable_prom_sink
-  - pgwatch.prometheus.new_prometheus.create_prometheus
-  - pgwatch.grafana.enable_grafana
-  - pgwatch.grafana.enable_datasources.postgres
-  - pgwatch.grafana.enable_datasources.prometheus
+Affected settings are listed below using their current camelCase names. If your
+values file still uses snake_case keys, see the separate snake_case migration
+warning below for the old -> new key mapping.
+
+Affected boolean settings include:
+  - pgwatch.postgres.enablePgSink
+  - pgwatch.postgres.createMetricDatabase
+  - pgwatch.prometheus.enablePromSink
+  - pgwatch.prometheus.newPrometheus.createPrometheus
+  - pgwatch.grafana.enableGrafana
+  - pgwatch.grafana.enableDatasources.postgres
+  - pgwatch.grafana.enableDatasources.prometheus
+{{- end }}
+
+{{- if include "pgwatch.hasLegacyRenamedValues" . }}
+WARNING:
+Detected legacy snake_case values in pgwatch chart values.
+
+These keys were renamed to camelCase to follow Helm naming conventions. The
+snake_case keys still work for backward compatibility, but support will be
+removed in the next major chart version. Please migrate your values:
+
+  pgwatch.postgres.enable_pg_sink -> pgwatch.postgres.enablePgSink
+  pgwatch.postgres.settings.retention_days -> pgwatch.postgres.settings.retentionDays
+  pgwatch.postgres.create_metric_database -> pgwatch.postgres.createMetricDatabase
+  pgwatch.postgres.new_pg_database -> pgwatch.postgres.newPgDatabase
+  pgwatch.postgres.use_existing_database -> pgwatch.postgres.useExistingDatabase
+  pgwatch.postgres.use_existing_database.grafana_database -> pgwatch.postgres.useExistingDatabase.grafanaDatabase
+  pgwatch.prometheus.enable_prom_sink -> pgwatch.prometheus.enablePromSink
+  pgwatch.prometheus.new_prometheus -> pgwatch.prometheus.newPrometheus
+  pgwatch.prometheus.new_prometheus.create_prometheus -> pgwatch.prometheus.newPrometheus.createPrometheus
+  pgwatch.prometheus.new_prometheus.settings.retention_days -> pgwatch.prometheus.newPrometheus.settings.retentionDays
+  pgwatch.grafana.enable_grafana -> pgwatch.grafana.enableGrafana
+  pgwatch.grafana.enable_datasources -> pgwatch.grafana.enableDatasources
 {{- end }}
 
 {{- if include "pgwatch.hasLegacyExternalDbInlineCredentials" . }}
 WARNING:
 Detected deprecated inline external database credentials under:
 
-  pgwatch.postgres.use_existing_database.username
-  pgwatch.postgres.use_existing_database.password
+  pgwatch.postgres.useExistingDatabase.username
+  pgwatch.postgres.useExistingDatabase.password
 
 Please migrate to one of the new secret-backed options:
   - pgwatch.postgres.credentials.username / password
   - pgwatch.postgres.credentials.existingSecret
 {{- end }}
 
-{{- if or (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
-          .Values.pgwatch.postgres.use_existing_database }}
+{{- if or (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
+          (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
 
 Credential Secret:
   kubectl get secret {{ include "pgwatch.credentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
 {{- end }}
 
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
           (not .Values.timescaledb.enabled) }}
 Postgres Admin Secret:
   kubectl get secret {{ include "pgwatch.adminCredentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -84,7 +84,7 @@ pgwatch.dbHost
 
   Behavior:
     - timescaledb.enabled true           -> "<release-name>-timescaledb"                   (subchart service)
-    - use_existing_database configured   -> use_existing_database.endpoint                 (external instance)
+    - useExistingDatabase configured     -> useExistingDatabase.endpoint                   (external instance)
     - otherwise                          -> "postgres-svc"                                 (built-in StatefulSet)
 
   Usage:
@@ -93,11 +93,179 @@ pgwatch.dbHost
 {{- define "pgwatch.dbHost" -}}
 {{- if .Values.timescaledb.enabled -}}
 {{ .Release.Name }}-timescaledb
-{{- else if .Values.pgwatch.postgres.use_existing_database -}}
-{{ .Values.pgwatch.postgres.use_existing_database.endpoint }}
+{{- else if include "pgwatch.postgres.hasUseExistingDatabase" . -}}
+{{ include "pgwatch.postgres.useExistingDatabase.endpoint" . }}
 {{- else -}}
 postgres-svc
 {{- end -}}
+{{- end }}
+
+{{/*
+Backward-compatible value helpers for keys renamed from snake_case to camelCase.
+Legacy snake_case values take precedence when explicitly present so existing
+values files keep working until support is removed in the next major version.
+*/}}
+{{- define "pgwatch.postgres.enablePgSink" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- if hasKey $pg "enable_pg_sink" -}}{{ $pg.enable_pg_sink }}{{- else -}}{{ $pg.enablePgSink }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.createMetricDatabase" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- if hasKey $pg "create_metric_database" -}}{{ $pg.create_metric_database }}{{- else -}}{{ $pg.createMetricDatabase }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.settings.retentionDays" -}}
+{{- $settings := .Values.pgwatch.postgres.settings | default dict -}}
+{{- if hasKey $settings "retention_days" -}}{{ $settings.retention_days }}{{- else -}}{{ $settings.retentionDays }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.newPgDatabase.image" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.newPgDatabase | default dict -}}
+{{- if hasKey $pg "new_pg_database" -}}
+  {{- $db = $pg.new_pg_database | default dict -}}
+{{- end -}}
+{{- $db.image -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.newPgDatabase.volume.size" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.newPgDatabase | default dict -}}
+{{- if hasKey $pg "new_pg_database" -}}
+  {{- $db = $pg.new_pg_database | default dict -}}
+{{- end -}}
+{{- ($db.volume | default dict).size -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.newPgDatabase.volume.storageClass" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.newPgDatabase | default dict -}}
+{{- if hasKey $pg "new_pg_database" -}}
+  {{- $db = $pg.new_pg_database | default dict -}}
+{{- end -}}
+{{- ($db.volume | default dict).storageClass -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.hasUseExistingDatabase" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- if or $pg.useExistingDatabase $pg.use_existing_database -}}true{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.endpoint" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.endpoint -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.port" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.port -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.database" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.database -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.sslmode" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.sslmode -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.grafanaDatabase" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- if hasKey $db "grafana_database" -}}{{ $db.grafana_database }}{{- else -}}{{ $db.grafanaDatabase | default "pgwatch_grafana" }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.username" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.username -}}
+{{- end }}
+
+{{- define "pgwatch.postgres.useExistingDatabase.password" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $db := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
+{{- $db.password -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.enablePromSink" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- if hasKey $prom "enable_prom_sink" -}}{{ $prom.enable_prom_sink }}{{- else -}}{{ $prom.enablePromSink }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.newPrometheus.createPrometheus" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- if hasKey $newProm "create_prometheus" -}}{{ $newProm.create_prometheus }}{{- else -}}{{ $newProm.createPrometheus }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.newPrometheus.image" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- $newProm.image -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.newPrometheus.settings.retentionDays" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- $settings := $newProm.settings | default dict -}}
+{{- if hasKey $settings "retention_days" -}}{{ $settings.retention_days }}{{- else -}}{{ $settings.retentionDays }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.newPrometheus.volume.size" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- ($newProm.volume | default dict).size -}}
+{{- end }}
+
+{{- define "pgwatch.prometheus.newPrometheus.volume.storageClass" -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- ($newProm.volume | default dict).storageClass -}}
+{{- end }}
+
+{{- define "pgwatch.grafana.enableGrafana" -}}
+{{- $grafana := .Values.pgwatch.grafana -}}
+{{- if hasKey $grafana "enable_grafana" -}}{{ $grafana.enable_grafana }}{{- else -}}{{ $grafana.enableGrafana }}{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.grafana.enableDatasources.postgres" -}}
+{{- $grafana := .Values.pgwatch.grafana -}}
+{{- $ds := $grafana.enableDatasources | default dict -}}
+{{- if hasKey $grafana "enable_datasources" -}}
+  {{- $ds = $grafana.enable_datasources | default dict -}}
+{{- end -}}
+{{- $ds.postgres -}}
+{{- end }}
+
+{{- define "pgwatch.grafana.enableDatasources.prometheus" -}}
+{{- $grafana := .Values.pgwatch.grafana -}}
+{{- $ds := $grafana.enableDatasources | default dict -}}
+{{- if hasKey $grafana "enable_datasources" -}}
+  {{- $ds = $grafana.enable_datasources | default dict -}}
+{{- end -}}
+{{- $ds.prometheus -}}
 {{- end }}
 
 {{/*
@@ -137,15 +305,28 @@ pgwatch.hasLegacyBoolValues
   a legacy string ("true" / "false"). Used for deprecation notices.
 */}}
 {{- define "pgwatch.hasLegacyBoolValues" -}}
-{{- $values := list
-  .Values.pgwatch.postgres.enable_pg_sink
-  .Values.pgwatch.postgres.create_metric_database
-  .Values.pgwatch.prometheus.enable_prom_sink
-  .Values.pgwatch.prometheus.new_prometheus.create_prometheus
-  .Values.pgwatch.grafana.enable_grafana
-  .Values.pgwatch.grafana.enable_datasources.postgres
-  .Values.pgwatch.grafana.enable_datasources.prometheus
--}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.newPrometheus | default dict -}}
+{{- if hasKey $prom "new_prometheus" -}}
+  {{- $newProm = $prom.new_prometheus | default dict -}}
+{{- end -}}
+{{- $grafana := .Values.pgwatch.grafana -}}
+{{- $ds := $grafana.enableDatasources | default dict -}}
+{{- if hasKey $grafana "enable_datasources" -}}
+  {{- $ds = $grafana.enable_datasources | default dict -}}
+{{- end -}}
+{{- $enablePgSink := $pg.enablePgSink -}}
+{{- if hasKey $pg "enable_pg_sink" -}}{{- $enablePgSink = $pg.enable_pg_sink -}}{{- end -}}
+{{- $createMetricDatabase := $pg.createMetricDatabase -}}
+{{- if hasKey $pg "create_metric_database" -}}{{- $createMetricDatabase = $pg.create_metric_database -}}{{- end -}}
+{{- $enablePromSink := $prom.enablePromSink -}}
+{{- if hasKey $prom "enable_prom_sink" -}}{{- $enablePromSink = $prom.enable_prom_sink -}}{{- end -}}
+{{- $createPrometheus := $newProm.createPrometheus -}}
+{{- if hasKey $newProm "create_prometheus" -}}{{- $createPrometheus = $newProm.create_prometheus -}}{{- end -}}
+{{- $enableGrafana := $grafana.enableGrafana -}}
+{{- if hasKey $grafana "enable_grafana" -}}{{- $enableGrafana = $grafana.enable_grafana -}}{{- end -}}
+{{- $values := list $enablePgSink $createMetricDatabase $enablePromSink $createPrometheus $enableGrafana $ds.postgres $ds.prometheus -}}
 {{- $state := dict "hasLegacy" false -}}
 {{- range $values -}}
   {{- if include "pgwatch.isLegacyBoolString" . -}}
@@ -207,8 +388,35 @@ pgwatch.hasLegacyExternalDbInlineCredentials
   True when deprecated external DB username/password fields are still used.
 */}}
 {{- define "pgwatch.hasLegacyExternalDbInlineCredentials" -}}
-{{- $existingDb := .Values.pgwatch.postgres.use_existing_database | default dict -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $existingDb := $pg.useExistingDatabase | default $pg.use_existing_database | default dict -}}
 {{- if or $existingDb.username $existingDb.password -}}
+true
+{{- end -}}
+{{- end }}
+
+{{- define "pgwatch.hasLegacyRenamedValues" -}}
+{{- $pg := .Values.pgwatch.postgres -}}
+{{- $prom := .Values.pgwatch.prometheus -}}
+{{- $newProm := $prom.new_prometheus | default dict -}}
+{{- $grafana := .Values.pgwatch.grafana -}}
+{{- $legacyDs := $grafana.enable_datasources | default dict -}}
+{{- if or
+  (hasKey $pg "enable_pg_sink")
+  (hasKey ($pg.settings | default dict) "retention_days")
+  (hasKey $pg "create_metric_database")
+  (hasKey $pg "new_pg_database")
+  (hasKey $pg "use_existing_database")
+  (hasKey ($pg.useExistingDatabase | default $pg.use_existing_database | default dict) "grafana_database")
+  (hasKey $prom "enable_prom_sink")
+  (hasKey $prom "new_prometheus")
+  (hasKey $newProm "create_prometheus")
+  (hasKey (($newProm.settings | default dict)) "retention_days")
+  (hasKey $grafana "enable_grafana")
+  (hasKey $grafana "enable_datasources")
+  (hasKey $legacyDs "postgres")
+  (hasKey $legacyDs "prometheus")
+-}}
 true
 {{- end -}}
 {{- end }}

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -9,7 +9,7 @@
 
   Rendered when:
     - timescaledb.enabled: true   (TimescaleDB subchart is the backend)
-    - OR create_metric_database: "true"  (built-in PostgreSQL StatefulSet)
+    - OR createMetricDatabase: "true"  (built-in PostgreSQL StatefulSet)
 
   Admin credentials are sourced from:
     - TimescaleDB, generated secret  : Secret <release>-timescaledb           key postgres-password
@@ -21,7 +21,7 @@
     - OR Secret pgwatch-postgresql-secret-pgwatch  keys username / password (default)
 ==============================================================================
 */}}
-{{- if or .Values.timescaledb.enabled (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) }}
+{{- if or .Values.timescaledb.enabled (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44,7 +44,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: db-init
-          image: {{ .Values.pgwatch.postgres.new_pg_database.image }}
+          image: {{ (include "pgwatch.postgres.newPgDatabase.image" .) }}
           env:
             - name: PGHOST
               value: {{ include "pgwatch.dbHost" . }}

--- a/helm/pgwatch/templates/grafana-dashboard-config.yaml
+++ b/helm/pgwatch/templates/grafana-dashboard-config.yaml
@@ -3,7 +3,7 @@
   When useSubchart: true the official Grafana subchart sidecar discovers
   dashboards via the grafana_dashboard ConfigMap label — no provider file needed.
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.grafana.enableGrafana" .)) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,7 +15,7 @@ data:
   dashboards_provider.yml: |
     apiVersion: 1
     providers:
-    {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
+    {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.enablePgSink" .) }}
     - name: 'pgwatch-postgres'
       orgId: 1
       folder: 'PostgreSQL'
@@ -23,7 +23,7 @@ data:
       options:
         path: /var/lib/grafana/dashboards/postgresql
     {{- end }}
-    {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
+    {{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.enablePromSink" .) }}
     - name: 'pgwatch-prometheus'
       orgId: 1
       folder: 'Prometheus'

--- a/helm/pgwatch/templates/grafana-deployment.yaml
+++ b/helm/pgwatch/templates/grafana-deployment.yaml
@@ -2,7 +2,7 @@
   Skipped when pgwatch.grafana.useSubchart: true — the official Grafana subchart
   provides the Grafana instance in that case (see grafana: top-level values block).
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.grafana.enableGrafana" .)) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +36,7 @@ spec:
               value: /var/lib/grafana/dashboards/postgresql/1-global-db-overview.json
           #  - name: GF_INSTALL_PLUGINS
           #    value: marcusolsson-treemap-panel
-            {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
+            {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .) }}
             - name: GF_DATABASE_TYPE
               value: postgres
             - name: GF_DATABASE_HOST
@@ -66,17 +66,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "pgwatch.credentialSecretName" . }}
                   key: {{ include "pgwatch.credentialPasswordKey" . }}
-            {{- else if .Values.pgwatch.postgres.use_existing_database }}
+            {{- else if (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
             - name: GF_DATABASE_TYPE
               value: postgres
             - name: GF_DATABASE_HOST
-              value: {{ .Values.pgwatch.postgres.use_existing_database.endpoint }}
+              value: {{ (include "pgwatch.postgres.useExistingDatabase.endpoint" .) }}
               # TODO: Port?
-              # value: "{{ .Values.pgwatch.postgres.use_existing_database.endpoint }}:{{ .Values.pgwatch.postgres.use_existing_database.port }}"
+              # value: "{{ (include "pgwatch.postgres.useExistingDatabase.endpoint" .) }}:{{ (include "pgwatch.postgres.useExistingDatabase.port" .) }}"
             - name: GF_DATABASE_NAME
-              value: {{ .Values.pgwatch.postgres.use_existing_database.grafana_database | default "pgwatch_grafana" }}
+              value: {{ (include "pgwatch.postgres.useExistingDatabase.grafanaDatabase" .) | default "pgwatch_grafana" }}
             - name: GF_DATABASE_SSL_MODE
-              value: {{ .Values.pgwatch.postgres.use_existing_database.sslmode }}
+              value: {{ (include "pgwatch.postgres.useExistingDatabase.sslmode" .) }}
             - name: GF_DATABASE_USER
               valueFrom:
                 secretKeyRef:
@@ -136,7 +136,7 @@ spec:
           projected:
             defaultMode: 416
             sources:
-              {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
+              {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.enablePgSink" .) }}
               {{- range $path, $_ := .Files.Glob "dashboards/postgresql/*.json" }}
               - configMap:
                   name: "grafana-postgresql-dashboard-{{ base $path | lower | replace "." "-" | replace "_" "-" }}"
@@ -146,7 +146,7 @@ spec:
               {{- end }}
               {{- end }}
 
-              {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
+              {{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.enablePromSink" .) }}
               {{- range $path, $_ := .Files.Glob "dashboards/prometheus/*.json" }}
               - configMap:
                   name: "grafana-prometheus-dashboard-{{ base $path | lower | replace "." "-" | replace "_" "-" }}"
@@ -170,7 +170,7 @@ spec:
     provisioning directory — no pod restart required.
 
 */}}
-{{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.grafana.enableGrafana" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -193,8 +193,8 @@ data:
   postgres_datasource.yml: |
     apiVersion: 1
     datasources:
-  {{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.postgres }}
-  {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
+  {{- if include "pgwatch.isTrue" (include "pgwatch.grafana.enableDatasources.postgres" .) }}
+  {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .) }}
     - name: pgwatch-metrics
       type: postgres
       url: "{{ include "pgwatch.dbHost" . }}:5432"
@@ -210,23 +210,23 @@ data:
         password: "${PGWATCH_METRICS_DS_PASSWORD}"
       version: 1
       editable: true
-  {{- else if .Values.pgwatch.postgres.use_existing_database }}
+  {{- else if (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
     - name: pgwatch-metrics
       type: postgres
-      url: {{ .Values.pgwatch.postgres.use_existing_database.endpoint }}:{{ .Values.pgwatch.postgres.use_existing_database.port }}
+      url: {{ (include "pgwatch.postgres.useExistingDatabase.endpoint" .) }}:{{ (include "pgwatch.postgres.useExistingDatabase.port" .) }}
       access: proxy
       user: "${PGWATCH_METRICS_DS_USER}"
       isDefault: true
       jsonData:
-        database: {{ .Values.pgwatch.postgres.use_existing_database.database }}
-        sslmode: {{ .Values.pgwatch.postgres.use_existing_database.sslmode | default "disable" }}
+        database: {{ (include "pgwatch.postgres.useExistingDatabase.database" .) }}
+        sslmode: {{ (include "pgwatch.postgres.useExistingDatabase.sslmode" .) | default "disable" }}
       secureJsonData:
         password: "${PGWATCH_METRICS_DS_PASSWORD}"
       version: 1
       editable: true
   {{ end }}
   {{ end }}
-  {{- if include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.prometheus }}
+  {{- if include "pgwatch.isTrue" (include "pgwatch.grafana.enableDatasources.prometheus" .) }}
     - name: PROMETHEUS
       type: prometheus
       access: proxy
@@ -239,7 +239,7 @@ data:
       basicAuthUser:
       basicAuthPassword:
       withCredentials:
-      {{- if not (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_datasources.postgres) }}
+      {{- if not (include "pgwatch.isTrue" (include "pgwatch.grafana.enableDatasources.postgres" .)) }}
       isDefault: true
       {{- end}}
       version: 1

--- a/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
@@ -1,4 +1,4 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.postgres.enablePgSink" .) }}
 {{- range $path, $_ := .Files.Glob "dashboards/postgresql/*.json" }}
 {{- $filename := base $path }}
 {{- $name := $filename | lower | replace "." "-" | replace "_" "-" }}

--- a/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
@@ -1,4 +1,4 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.enablePromSink" .) }}
 {{- range $path, $_ := .Files.Glob "dashboards/prometheus/*.json" }}
 {{- $filename := base $path }}
 {{- $name := $filename | lower | replace "." "-" | replace "_" "-" }}

--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -31,7 +31,7 @@ spec:
               secretKeyRef:
                 name: {{ include "pgwatch.credentialSecretName" . }}
                 key: {{ include "pgwatch.credentialPasswordKey" . }}
-        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database }}
+        {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .) }}
           - name: METRIC_DATABASE_ENDPOINT
             value: "{{ include "pgwatch.dbHost" . }}.{{ .Release.Namespace }}.svc.cluster.local"
           - name: METRIC_DATABASE_PORT
@@ -40,23 +40,23 @@ spec:
             value: pgwatch_metrics
           - name: METRIC_DATABASE_SSLMODE
             value: disable
-        {{- else if .Values.pgwatch.postgres.use_existing_database }}
+        {{- else if (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
           - name: METRIC_DATABASE_ENDPOINT
-            value: {{ .Values.pgwatch.postgres.use_existing_database.endpoint }}
+            value: {{ (include "pgwatch.postgres.useExistingDatabase.endpoint" .) }}
           - name: METRIC_DATABASE_PORT
-            value: "{{ .Values.pgwatch.postgres.use_existing_database.port }}"
+            value: "{{ (include "pgwatch.postgres.useExistingDatabase.port" .) }}"
           - name: METRIC_DATABASE_DATABASE
-            value: {{ .Values.pgwatch.postgres.use_existing_database.database }}
+            value: {{ (include "pgwatch.postgres.useExistingDatabase.database" .) }}
           - name: METRIC_DATABASE_SSLMODE
-            value: {{ .Values.pgwatch.postgres.use_existing_database.sslmode }}
+            value: {{ (include "pgwatch.postgres.useExistingDatabase.sslmode" .) }}
         {{ end }}
-        {{- if include "pgwatch.isTrue" .Values.pgwatch.postgres.enable_pg_sink }}
+        {{- if include "pgwatch.isTrue" (include "pgwatch.postgres.enablePgSink" .) }}
           - name: PG_IS_SINK
             value: "true"
           - name: PG_RETENTION_DAYS
-            value: "{{ .Values.pgwatch.postgres.settings.retention_days }} days"
+            value: "{{ (include "pgwatch.postgres.settings.retentionDays" .) }} days"
         {{ end }}
-        {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
+        {{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.enablePromSink" .) }}
           - name: PROM_IS_SINK
             value: "true"
         {{ end }}
@@ -92,7 +92,7 @@ spec:
           ports:
             - containerPort: {{ .Values.pgwatch.webPort }}
               protocol: TCP
-        {{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.enable_prom_sink }}
+        {{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.enablePromSink" .) }}
             - containerPort: 9188
               protocol: TCP
         {{ end }}

--- a/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
@@ -1,6 +1,6 @@
 # File to configure the Alertmanager
 # This file is part of the CPO monitoring stack from CYBERTEC PostgreSQL International GmbH.
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/pgwatch/templates/postgres-statefulset.yaml
+++ b/helm/pgwatch/templates/postgres-statefulset.yaml
@@ -2,7 +2,7 @@
   Skipped when timescaledb.enabled: true — the TimescaleDB subchart provides the
   database in that case and db-init-job.yaml handles schema/user bootstrapping.
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) (not .Values.timescaledb.enabled) }}
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .)) (not .Values.timescaledb.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -27,7 +27,7 @@ spec:
         env:
         - name: PGDATA
           value: /pgdata/data
-        image: {{ .Values.pgwatch.postgres.new_pg_database.image }}
+        image: {{ (include "pgwatch.postgres.newPgDatabase.image" .) }}
         command:
         - /bin/sh
         - -c
@@ -50,7 +50,7 @@ spec:
       containers:
       - name: postgres
         {{- include "pgwatch.containerSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.postgres.securityContext) | nindent 8 }}
-        image: {{ .Values.pgwatch.postgres.new_pg_database.image }}
+        image: {{ (include "pgwatch.postgres.newPgDatabase.image" .) }}
         ports:
         - containerPort: 5432
           name: postgres
@@ -83,8 +83,8 @@ spec:
         pgwatch.pods.role: postgres
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.pgwatch.postgres.new_pg_database.volume.storageClass }}
+      storageClassName: {{ (include "pgwatch.postgres.newPgDatabase.volume.storageClass" .) }}
       resources:
         requests:
-          storage: {{ .Values.pgwatch.postgres.new_pg_database.volume.size }}
+          storage: {{ (include "pgwatch.postgres.newPgDatabase.volume.size" .) }}
 {{ end }}

--- a/helm/pgwatch/templates/prometheus-config.yaml
+++ b/helm/pgwatch/templates/prometheus-config.yaml
@@ -1,4 +1,4 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/helm/pgwatch/templates/prometheus-deployment.yaml
+++ b/helm/pgwatch/templates/prometheus-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,7 +36,7 @@ spec:
         - mountPath: /prometheus
           name: prometheus-volume
       containers:
-      - image: {{ .Values.pgwatch.prometheus.new_prometheus.image }}
+      - image: {{ (include "pgwatch.prometheus.newPrometheus.image" .) }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -77,7 +77,7 @@ spec:
         args:
           - "--config.file=/etc/prometheus/prometheus.yml"
           - "--storage.tsdb.path=/prometheus"
-          - "--storage.tsdb.retention.time={{ .Values.pgwatch.prometheus.new_prometheus.settings.retention_days }}d"
+          - "--storage.tsdb.retention.time={{ (include "pgwatch.prometheus.newPrometheus.settings.retentionDays" .) }}d"
         {{- include "pgwatch.containerSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.prometheus.securityContext) | nindent 8 }}
         volumeMounts:
         - mountPath: /etc/prometheus

--- a/helm/pgwatch/templates/pvcs.yaml
+++ b/helm/pgwatch/templates/pvcs.yaml
@@ -1,4 +1,4 @@
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -13,6 +13,6 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.pgwatch.prometheus.new_prometheus.volume.size }}
-  storageClassName: {{ .Values.pgwatch.prometheus.new_prometheus.volume.storageClass }}
+      storage: {{ (include "pgwatch.prometheus.newPrometheus.volume.size" .) }}
+  storageClassName: {{ (include "pgwatch.prometheus.newPrometheus.volume.storageClass" .) }}
 {{ end }}

--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -1,17 +1,16 @@
-{{- if or (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
-          .Values.pgwatch.postgres.use_existing_database }}
+{{- if or (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
+          (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
 
 {{/*
   Credential resolution via coalesce (first non-empty value wins):
   1. credentials.{username,password} (new)
-  2. use_existing_database.{username,password} (legacy, deprecated)
+  2. useExistingDatabase.{username,password} (legacy, deprecated)
   3. "pgwatch" (default username only)
 */}}
 {{- $creds      := .Values.pgwatch.postgres.credentials      | default dict -}}
 {{- $adminCreds := .Values.pgwatch.postgres.adminCredentials | default dict -}}
-{{- $existingDb := .Values.pgwatch.postgres.use_existing_database | default dict -}}
-{{- $pgwatchUsername := coalesce $creds.username $existingDb.username "pgwatch" -}}
-{{- $pgwatchPassword := coalesce $creds.password $existingDb.password -}}
+{{- $pgwatchUsername := coalesce $creds.username (include "pgwatch.postgres.useExistingDatabase.username" .) "pgwatch" -}}
+{{- $pgwatchPassword := coalesce $creds.password (include "pgwatch.postgres.useExistingDatabase.password" .) -}}
 
 {{/*
   pgwatch-postgresql-secret-postgres — admin (superuser) credentials.
@@ -19,7 +18,7 @@
   When timescaledb.enabled: true the TimescaleDB subchart manages its own
   admin secret and this one is not created.
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database)
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
           (not .Values.timescaledb.enabled)
           (not $adminCreds.existingSecret) }}
 apiVersion: v1

--- a/helm/pgwatch/templates/services.yaml
+++ b/helm/pgwatch/templates/services.yaml
@@ -10,7 +10,7 @@ spec:
     - name: pgwatch
       port: {{ .Values.pgwatch.webPort }}
       targetPort: {{ .Values.pgwatch.webPort }}
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
     - name: pgwatch-prometheus-sink
       port: 9188
       targetPort: 9188
@@ -23,7 +23,7 @@ spec:
   grafana-svc is only needed for the custom Grafana Deployment.
   When useSubchart: true the official Grafana subchart creates its own Service.
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.grafana.enable_grafana) (not .Values.pgwatch.grafana.useSubchart) }}
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.grafana.enableGrafana" .)) (not .Values.pgwatch.grafana.useSubchart) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -45,7 +45,7 @@ spec:
   postgres-svc is only needed for the built-in PostgreSQL StatefulSet.
   When timescaledb.enabled: true the TimescaleDB subchart creates its own Service.
 */}}
-{{- if and (include "pgwatch.isTrue" .Values.pgwatch.postgres.create_metric_database) (not .Values.timescaledb.enabled) }}
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .)) (not .Values.timescaledb.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -63,7 +63,7 @@ spec:
     pgwatch.pods.role: postgres
 {{ end }}
 ---
-{{- if include "pgwatch.isTrue" .Values.pgwatch.prometheus.new_prometheus.create_prometheus }}
+{{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -114,25 +114,26 @@ pgwatch:
   # == Metrics sink: PostgreSQL ==
 
   postgres:
-    enable_pg_sink: true
+    enablePgSink: true
     settings:
-      retention_days: 31
+      retentionDays: 31
 
     # -- Set to true to deploy a new PostgreSQL StatefulSet (default).
-    create_metric_database: true
-    # -- New PostgreSQL instance — active when create_metric_database: true.
-    new_pg_database:
+    createMetricDatabase: true
+    # -- New PostgreSQL instance — active when createMetricDatabase: true.
+    newPgDatabase:
       image: "docker.io/postgres:18.3-alpine3.23"
       volume:
         size: '10Gi'
         storageClass: 'standard'
 
-    # -- External database connection (active when create_metric_database: false).
+    # -- External database connection (active when createMetricDatabase: false).
     # Set credentials via credentials.* below; username/password here are deprecated.
-    # use_existing_database:
+    # useExistingDatabase:
     #   endpoint: postgresql.local
     #   port:     '5432'
     #   database: PGWATCH_DATABASE
+    #   grafanaDatabase: pgwatch_grafana # optional, default: pgwatch_grafana
     #   sslmode:  require
     #   # username: # DEPRECATED, use credentials.username
     #   # password: # DEPRECATED, use credentials.password
@@ -142,7 +143,7 @@ pgwatch:
     # Precedence:
     #   1. credentials.existingSecret — chart creates no Secret; keys read via usernameKey/passwordKey
     #   2. credentials.username / password — chart creates pgwatch-postgresql-secret-pgwatch
-    #   3. DEPRECATED: use_existing_database.username / password — still works, emits warning
+    #   3. DEPRECATED: useExistingDatabase.username / password — still works, emits warning
     credentials:
       # -- Name of an existing Secret that contains the pgwatch username/password.
       # When set, the chart will not create pgwatch-postgresql-secret-pgwatch.
@@ -155,7 +156,7 @@ pgwatch:
       passwordKey: "password"
 
     # -- Admin password for the built-in PostgreSQL StatefulSet.
-    # Only applies when create_metric_database: true and timescaledb.enabled: false.
+    # Only applies when createMetricDatabase: true and timescaledb.enabled: false.
     # Has no effect for external databases or TimescaleDB subchart.
     adminCredentials:
       # -- Password for the postgres superuser stored in the admin Secret.
@@ -186,19 +187,19 @@ pgwatch:
   # == Metrics sink: Prometheus ==
 
   prometheus:
-    enable_prom_sink: true
+    enablePromSink: true
 
-    # -- New Prometheus instance — active when create_prometheus: true.
-    new_prometheus:
-      create_prometheus: true
+    # -- New Prometheus instance — active when createPrometheus: true.
+    newPrometheus:
+      createPrometheus: true
       image: "prom/prometheus:main"
       settings:
-        retention_days: 31
+        retentionDays: 31
       volume:
         size: '10Gi'
         storageClass: 'standard'
 
-    # -- Existing Prometheus instance — active when create_prometheus: false.
+    # -- Existing Prometheus instance — active when createPrometheus: false.
     #
     # TODO: Implement use_existing_prometheus
     #
@@ -237,11 +238,11 @@ pgwatch:
     # When false (default): the custom Deployment runs exactly as before.
     useSubchart: false
     image: grafana/grafana:12.4.0-21419697389 # Dashboards are prepared for grafana v12
-    enable_grafana: true
+    enableGrafana: true
     # -- Controls which Grafana datasources are provisioned.
-    # Independent of the sink settings (enable_pg_sink / enable_prom_sink), which control
+    # Independent of the sink settings (enablePgSink / enablePromSink), which control
     # what pgwatch writes to. These control what Grafana is configured to query.
-    enable_datasources:
+    enableDatasources:
       postgres: true
       prometheus: true
 


### PR DESCRIPTION
* Document previously used snake_case values in README.md
* Add backward-compatible snake_case fallbacks
* Add deprecation warning to NOTES.txt

Fixes #22.

The warnings are as follows:
```
NOTES:
WARNING:
Detected legacy string boolean values ("true"/"false") in pgwatch chart values.

This compatibility behavior is deprecated and will be removed in the next chart
version. Please update your values files and overrides to use native YAML
booleans instead:

true
false

Affected settings are listed below using their current camelCase names. If your
values file still uses snake_case keys, see the separate snake_case migration
warning below for the old -> new key mapping.

Affected boolean settings include:
- pgwatch.postgres.enablePgSink
- pgwatch.postgres.createMetricDatabase
- pgwatch.prometheus.enablePromSink
- pgwatch.prometheus.newPrometheus.createPrometheus
- pgwatch.grafana.enableGrafana
- pgwatch.grafana.enableDatasources.postgres
- pgwatch.grafana.enableDatasources.prometheus
WARNING:
Detected legacy snake_case values in pgwatch chart values.

These keys were renamed to camelCase to follow Helm naming conventions. The
snake_case keys still work for backward compatibility, but support will be
removed in the next major chart version. Please migrate your values:

pgwatch.postgres.enable_pg_sink -> pgwatch.postgres.enablePgSink
pgwatch.postgres.settings.retention_days -> pgwatch.postgres.settings.retentionDays
pgwatch.postgres.create_metric_database -> pgwatch.postgres.createMetricDatabase
pgwatch.postgres.new_pg_database -> pgwatch.postgres.newPgDatabase
pgwatch.postgres.use_existing_database -> pgwatch.postgres.useExistingDatabase
pgwatch.postgres.use_existing_database.grafana_database -> pgwatch.postgres.useExistingDatabase.grafanaDatabase
pgwatch.prometheus.enable_prom_sink -> pgwatch.prometheus.enablePromSink
pgwatch.prometheus.new_prometheus -> pgwatch.prometheus.newPrometheus
pgwatch.prometheus.new_prometheus.create_prometheus -> pgwatch.prometheus.newPrometheus.createPrometheus
pgwatch.prometheus.new_prometheus.settings.retention_days -> pgwatch.prometheus.newPrometheus.settings.retentionDays
pgwatch.grafana.enable_grafana -> pgwatch.grafana.enableGrafana
pgwatch.grafana.enable_datasources -> pgwatch.grafana.enableDatasources
```