### PR TITLE
Implement Helm recommended Kubernetes labels

### DIFF
--- a/helm/pgwatch/Chart.yaml
+++ b/helm/pgwatch/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "3.2"
+appVersion: "5.2"
 description: A Helm chart for pgwatch monitoring tools
 name: pgwatch
-version: 3.1.0
+version: 4.0.0
 
 dependencies:
   # TimescaleDB subchart — opt-in replacement for the built-in PostgreSQL StatefulSet.

--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -335,8 +335,25 @@ kubectl delete deployment pgwatch -n pgwatch
 kubectl delete deployment grafana -n pgwatch
 kubectl delete deployment pgwatch-prometheus -n pgwatch
 kubectl delete statefulset postgres -n pgwatch --cascade=orphan
-helm upgrade pgwatch pgwatch/pgwatch -n pgwatch --values custom-values.yaml # or the equivalent command you use to helm upgrade your chart.
+helm upgrade pgwatch pgwatch/pgwatch -n pgwatch --values custom-values.yaml
 ```
+
+> **Note on the PostgreSQL StatefulSet:** `--cascade=orphan` prevents the old
+> `postgres-0` Pod from being deleted when the StatefulSet is removed. However,
+> because the selector labels also changed, the new StatefulSet cannot adopt the
+> orphaned Pod — its old labels no longer match the new selector. The StatefulSet
+> will be stuck trying to create `postgres-0` while the orphaned Pod is still
+> running under that name.
+>
+> If this happens, delete the orphaned Pod as well. Your data is stored in the
+> PVC, not in the Pod, so it is safe:
+>
+> ```sh
+> kubectl delete pod postgres-0 -n pgwatch
+> ```
+>
+> The new StatefulSet will then create a fresh `postgres-0` that attaches to the
+> existing PVC and reconnects to your data automatically.
 
 Adjust the commands to match the components enabled in your installation and
 the namespace/release name you use.

--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -335,7 +335,7 @@ kubectl delete deployment pgwatch -n pgwatch
 kubectl delete deployment grafana -n pgwatch
 kubectl delete deployment pgwatch-prometheus -n pgwatch
 kubectl delete statefulset postgres -n pgwatch --cascade=orphan
-helm upgrade pgwatch pgwatch/pgwatch -n pgwatch --values custom-values.yaml
+helm upgrade pgwatch pgwatch/pgwatch -n pgwatch --values custom-values.yaml # or the equivalent command you use to helm upgrade your chart.
 ```
 
 Adjust the commands to match the components enabled in your installation and

--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -43,6 +43,28 @@ helm upgrade pgwatch -n pgwatch -f custom-values.yaml .
 
 ```
 
+## Upgrade notes for chart 4.0.0
+
+### Breaking change: selector labels changed
+
+Chart 4.0.0 changes the selector labels of the built-in workloads to the
+standard `app.kubernetes.io/*` schema. Kubernetes treats `Deployment` and
+`StatefulSet` selectors as immutable, so upgrades from older chart versions may
+require deleting and recreating the affected workload objects.
+
+Before upgrading an existing installation, read
+[Breaking upgrade note: selector labels changed](#breaking-upgrade-note-selector-labels-changed).
+
+### Backward-compatible deprecations
+
+Chart 4.0.0 also prefers native YAML booleans (`true` / `false`) and Helm-style
+camelCase values. Legacy string booleans (`"true"` / `"false"`) and former
+snake_case value keys still work temporarily for backward compatibility and
+emit migration warnings during install/upgrade.
+
+See [Customisation](#customisation) for the current value names and migration
+mapping.
+
 ## Customisation
 
 The Helm chart currently supports PostgreSQL and Prometheus as a sink. This can be controlled via the [values](https://github.com/cybertec-postgresql/pgwatch-charts/blob/pgwatch-3-helm-chart/helm/pgwatch/values.yaml) file.
@@ -257,6 +279,67 @@ extraDeploy:
       endpoints:
         - port: metrics
 ```
+
+### Kubernetes Labels
+
+Resources rendered by this chart use Helm's [recommended Kubernetes label schema](https://helm.sh/docs/chart_best_practices/labels/):
+
+```yaml
+app.kubernetes.io/name: pgwatch
+app.kubernetes.io/instance: <release-name>
+app.kubernetes.io/component: <component>
+app.kubernetes.io/managed-by: <release-service>
+vendor: opensource.cybertec
+```
+
+`app.kubernetes.io/name: pgwatch` identifies the application, while
+`app.kubernetes.io/component` identifies the logical role within the pgwatch
+stack, such as `pgwatch`, `grafana`, `postgres`, `prometheus`, or `db-init`.
+
+Workload and Service selectors intentionally use the stable subset
+`app.kubernetes.io/name`, `app.kubernetes.io/instance`, and
+`app.kubernetes.io/component`. These selector labels are also present on the
+matching pod templates. Descriptive labels such as
+`app.kubernetes.io/managed-by` and `vendor` are not used in selectors so they
+can change without affecting controller upgrades or Service routing.
+
+Subcharts, such as the optional Grafana and TimescaleDB charts, manage their
+own labels. This chart only relies on their documented integration points, for
+example Grafana sidecar discovery labels such as `grafana_dashboard` and
+`grafana_datasource`.
+
+#### Breaking upgrade note: selector labels changed
+
+Chart 4.0.0 changes the selectors of the built-in `Deployment` and
+`StatefulSet` resources to use the standardized `app.kubernetes.io/*` labels.
+Kubernetes treats these selectors as immutable, so upgrades from chart versions
+that used the previous selector labels may fail with:
+
+```text
+field is immutable: spec.selector
+```
+
+Affected built-in workloads are:
+
+- `Deployment/pgwatch`
+- `Deployment/grafana` when `pgwatch.grafana.useSubchart=false`
+- `Deployment/pgwatch-prometheus` when `pgwatch.prometheus.newPrometheus.createPrometheus=true`
+- `StatefulSet/postgres` when using the built-in PostgreSQL database
+
+If an upgrade fails with an immutable selector error, delete the affected
+workload object and rerun `helm upgrade`. Do not delete PVCs unless you
+intentionally want to remove stored data. For example:
+
+```sh
+kubectl delete deployment pgwatch -n pgwatch
+kubectl delete deployment grafana -n pgwatch
+kubectl delete deployment pgwatch-prometheus -n pgwatch
+kubectl delete statefulset postgres -n pgwatch --cascade=orphan
+helm upgrade pgwatch pgwatch/pgwatch -n pgwatch --values custom-values.yaml
+```
+
+Adjust the commands to match the components enabled in your installation and
+the namespace/release name you use.
 
 ---
 

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -5,6 +5,56 @@
 */}}
 
 {{/*
+pgwatch.commonLabels
+  Internal helper for chart-managed resource metadata labels.
+
+  User-facing label semantics are documented in README.md. Keep this comment
+  focused on the helper calling convention and Helm context handling.
+
+  The helper receives a dict because Helm's include function accepts only one
+  data argument. The dict carries both:
+    - root:      the original chart root context, so the helper can access
+                 .Release.Name and .Release.Service even when called from
+                 inside a range/with block where the local dot (.) changed
+    - component: the logical component/role to render in
+                 app.kubernetes.io/component
+
+  Inputs:
+    - root:      the chart root context (.)
+    - component: logical component/role for the resource
+
+  Usage:
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
+    {{- include "pgwatch.commonLabels" (dict "root" $ "component" "grafana") | nindent 4 }}  # inside range/with
+*/}}
+{{- define "pgwatch.commonLabels" -}}
+app.kubernetes.io/name: pgwatch
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+vendor: opensource.cybertec
+{{- end }}
+
+{{/*
+pgwatch.selectorLabels
+  Internal helper for the stable label subset used by pod selectors.
+
+  Use this helper only where Kubernetes matches/selects pods, such as:
+    - spec.selector.matchLabels on Deployments/StatefulSets
+    - spec.selector on Services
+
+  Keep this as a subset of pgwatch.commonLabels. The selected pod template must
+  carry these labels as well.
+
+  Inputs and calling convention match pgwatch.commonLabels.
+*/}}
+{{- define "pgwatch.selectorLabels" -}}
+app.kubernetes.io/name: pgwatch
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end }}
+
+{{/*
 pgwatch.podSecurityContext
   Renders the pod-level securityContext for a given component.
 

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -32,6 +32,7 @@ app.kubernetes.io/name: pgwatch
 app.kubernetes.io/instance: {{ .root.Release.Name }}
 app.kubernetes.io/component: {{ .component }}
 app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+helm.sh/chart: "{{ .root.Chart.Name }}-{{ .root.Chart.Version | replace "+" "_" }}"
 vendor: opensource.cybertec
 {{- end }}
 

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -28,7 +28,7 @@ metadata:
   name: {{ .Release.Name }}-db-init
   namespace: {{ .Release.Namespace }}
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "db-init") | nindent 4 }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
@@ -38,8 +38,7 @@ spec:
   template:
     metadata:
       labels:
-        application: pgwatch
-        pgwatch.pods.role: db-init
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "db-init") | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       containers:

--- a/helm/pgwatch/templates/grafana-dashboard-config.yaml
+++ b/helm/pgwatch/templates/grafana-dashboard-config.yaml
@@ -9,8 +9,7 @@ kind: ConfigMap
 metadata:
   name: grafana-dashboard-config
   labels:
-    application: pgwatch
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "grafana") | nindent 4 }}
 data:
   dashboards_provider.yml: |
     apiVersion: 1

--- a/helm/pgwatch/templates/grafana-deployment.yaml
+++ b/helm/pgwatch/templates/grafana-deployment.yaml
@@ -7,23 +7,20 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: pgwatch
-    pgwatch.pods.role: grafana
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "grafana") | nindent 4 }}
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: pgwatch
-      pgwatch.pods.role: grafana
+      {{- include "pgwatch.selectorLabels" (dict "root" . "component" "grafana") | nindent 6 }}
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        application: pgwatch
-        pgwatch.pods.role: grafana
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "grafana") | nindent 8 }}
     spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.grafana.securityContext) | nindent 6 }}
       containers:
@@ -182,7 +179,7 @@ metadata:
     # Grafana subchart (useSubchart: true): picked up by the k8s-sidecar
     #   via the grafana_datasource: "1" label below.
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "grafana") | nindent 4 }}
     {{- if .Values.pgwatch.grafana.useSubchart }}
     # Watched by the Grafana subchart sidecar (sidecar.datasources.label: grafana_datasource).
     grafana_datasource: "1"

--- a/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-postgresql-dashboards.yaml
@@ -15,8 +15,7 @@ metadata:
     grafana_dashboard_folder: "postgresql"
   {{- end }}
   labels:
-    application: pgwatch
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" $ "component" "grafana") | nindent 4 }}
     grafana_dashboard: "1"
 data:
   {{ $filename }}: |-

--- a/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
+++ b/helm/pgwatch/templates/grafana-prometheus-dashboards.yaml
@@ -15,8 +15,7 @@ metadata:
     grafana_dashboard_folder: "prometheus"
   {{- end }}
   labels:
-    application: pgwatch
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" $ "component" "grafana") | nindent 4 }}
     grafana_dashboard: "1"
 data:
   {{ $filename }}: |-

--- a/helm/pgwatch/templates/ingress.yaml
+++ b/helm/pgwatch/templates/ingress.yaml
@@ -27,8 +27,7 @@ metadata:
   name: pgwatch-ingress
   namespace: {{ .Release.Namespace }}
   labels:
-    application: pgwatch
-    pgwatch.pods.role: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
   {{- with .Values.pgwatch.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/pgwatch/templates/pgwatch-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-config.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    application: pgwatch
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
   name: pgwatch-cm
 data:
   launcher.sh: |

--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -2,21 +2,18 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    application: pgwatch
-    pgwatch.pods.role: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
   name: pgwatch
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      application: pgwatch
-      pgwatch.pods.role: pgwatch
+      {{- include "pgwatch.selectorLabels" (dict "root" . "component" "pgwatch") | nindent 6 }}
   template:
     metadata:
       labels:
-        application: pgwatch
-        pgwatch.pods.role: pgwatch
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 8 }}
     spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.securityContext) | nindent 6 }}
       containers:

--- a/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-prometheus-alert-config.yaml
@@ -5,9 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: pgwatch
-    vendor: opensource.cybertec
-    postgres-operator.cybertec.at/stack: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
   name: pgwatch-prometheus-alerts
 data:
   pgwatch-prometheus-alert-rules.yml: |

--- a/helm/pgwatch/templates/pgwatch-sources-config.yaml
+++ b/helm/pgwatch/templates/pgwatch-sources-config.yaml
@@ -8,8 +8,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    application: pgwatch
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
   name: pgwatch-sources-cm
   namespace: {{ .Release.Namespace }}
 data:

--- a/helm/pgwatch/templates/postgres-statefulset.yaml
+++ b/helm/pgwatch/templates/postgres-statefulset.yaml
@@ -8,18 +8,18 @@ kind: StatefulSet
 metadata:
   name: postgres
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 4 }}
 spec:
   serviceName: "postgres-svc"
   replicas: 1
   selector:
     matchLabels:
-      application: pgwatch
-      pgwatch.pods.role: postgres
+      {{- include "pgwatch.selectorLabels" (dict "root" . "component" "postgres") | nindent 6 }}
   template:
     metadata:
       labels:
-        application: pgwatch
-        pgwatch.pods.role: postgres
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 8 }}
     spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.postgres.securityContext) | nindent 6 }}
       initContainers:
@@ -79,8 +79,7 @@ spec:
   - metadata:
       name: pgdata
       labels:
-        application: pgwatch
-        pgwatch.pods.role: postgres
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 8 }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ (include "pgwatch.postgres.newPgDatabase.volume.storageClass" .) }}

--- a/helm/pgwatch/templates/prometheus-config.yaml
+++ b/helm/pgwatch/templates/prometheus-config.yaml
@@ -3,8 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app.kubernetes.io/name: postgres-operator-monitoring
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
   name: pgwatch-prometheus-cm
 data:
   prometheus.yml: |

--- a/helm/pgwatch/templates/prometheus-deployment.yaml
+++ b/helm/pgwatch/templates/prometheus-deployment.yaml
@@ -3,21 +3,17 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/name: pgwatch
-    vendor: opensource.cybertec
-    postgres-operator.cybertec.at/stack: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
   name: pgwatch-prometheus
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
-      postgres-operator.cybertec.at/stack: pgwatch
-      name: pgwatch-prometheus
+      {{- include "pgwatch.selectorLabels" (dict "root" . "component" "prometheus") | nindent 6 }}
   template:
     metadata:
       labels:
-        postgres-operator.cybertec.at/stack: pgwatch
-        name: pgwatch-prometheus
+        {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 8 }}
     spec:
       {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.prometheus.securityContext) | nindent 6 }}
       initContainers:

--- a/helm/pgwatch/templates/pvcs.yaml
+++ b/helm/pgwatch/templates/pvcs.yaml
@@ -4,8 +4,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app.kubernetes.io/name: cpo-monitoring
-    vendor: opensource.cybertec
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
   name: prometheus-pvc
   namespace: {{ .Release.Namespace }}
 spec:

--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -50,7 +50,7 @@ metadata:
   name: pgwatch-postgresql-secret-pgwatch
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 4 }}
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
 type: Opaque
 stringData:
   password: {{ required

--- a/helm/pgwatch/templates/secrets.yaml
+++ b/helm/pgwatch/templates/secrets.yaml
@@ -26,6 +26,8 @@ kind: Secret
 metadata:
   name: pgwatch-postgresql-secret-postgres
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 4 }}
 type: Opaque
 stringData:
   password: {{ required
@@ -47,6 +49,8 @@ kind: Secret
 metadata:
   name: pgwatch-postgresql-secret-pgwatch
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 4 }}
 type: Opaque
 stringData:
   password: {{ required

--- a/helm/pgwatch/templates/services.yaml
+++ b/helm/pgwatch/templates/services.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
   name: pgwatch-svc
   namespace: {{ .Release.Namespace }}
 spec:
@@ -16,8 +16,7 @@ spec:
       targetPort: 9188
 {{ end }}
   selector:
-    application: pgwatch
-    pgwatch.pods.role: pgwatch
+    {{- include "pgwatch.selectorLabels" (dict "root" . "component" "pgwatch") | nindent 4 }}
 ---
 {{/*
   grafana-svc is only needed for the custom Grafana Deployment.
@@ -28,7 +27,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "grafana") | nindent 4 }}
   name: grafana-svc
   namespace: {{ .Release.Namespace }}
 spec:
@@ -37,8 +36,7 @@ spec:
       port: 3000
       targetPort: 3000
   selector:
-    application: pgwatch
-    pgwatch.pods.role: grafana
+    {{- include "pgwatch.selectorLabels" (dict "root" . "component" "grafana") | nindent 4 }}
 ---
 {{ end }}
 {{/*
@@ -50,7 +48,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "postgres") | nindent 4 }}
   name: postgres-svc
   namespace: {{ .Release.Namespace }}
 spec:
@@ -59,8 +57,7 @@ spec:
       port: 5432
       targetPort: 5432
   selector:
-    application: pgwatch
-    pgwatch.pods.role: postgres
+    {{- include "pgwatch.selectorLabels" (dict "root" . "component" "postgres") | nindent 4 }}
 {{ end }}
 ---
 {{- if include "pgwatch.isTrue" (include "pgwatch.prometheus.newPrometheus.createPrometheus" .) }}
@@ -68,7 +65,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    application: pgwatch
+    {{- include "pgwatch.commonLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
   name: pgwatch-prometheus-svc
   namespace: {{ .Release.Namespace }}
 spec:
@@ -77,5 +74,5 @@ spec:
   - name: prometheus
     port: 9090
   selector:
-    name: pgwatch-prometheus
+    {{- include "pgwatch.selectorLabels" (dict "root" . "component" "prometheus") | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
- Add shared helpers for common and selector labels
- Apply standardized app.kubernetes.io/* labels across chart resources
- Update workload and Service selectors to use the new label schema
- Bump chart to 4.0.0 and pgwatch appVersion to 5.2
- Document chart 4.0.0 upgrade notes and selector migration guidance

The selector label changes are breaking changes. Those are explicitly mentioned in the README.md.

Fixes #23.

This is probably the final PR to merge. After that, I would like to run the last checks and tests, and then release the 4.0.0 version of the Chart. 

please review. 