### PR TITLE
Add seccompProfile.type: RuntimeDefault in global securityContext settings

### DIFF
--- a/helm/pgwatch/CHANGELOG.md
+++ b/helm/pgwatch/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `seccompProfile.type: RuntimeDefault` in global `securityContext.pod` defaults when `securityContext.enabled=true` ([#31](https://github.com/cybertec-postgresql/pgwatch-charts/issues/31)).
 
+### Fixed
+
+- `db-init` hook Job now honors global and PostgreSQL component `securityContext` settings.
+
 ## [4.0.0] – 2026-05-07
 
 ### Breaking changes

--- a/helm/pgwatch/CHANGELOG.md
+++ b/helm/pgwatch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `seccompProfile.type: RuntimeDefault` in global `securityContext.pod` defaults when `securityContext.enabled=true` ([#31](https://github.com/cybertec-postgresql/pgwatch-charts/issues/31)).
+
 ## [4.0.0] – 2026-05-07
 
 ### Breaking changes

--- a/helm/pgwatch/README.md
+++ b/helm/pgwatch/README.md
@@ -330,6 +330,17 @@ Security contexts can be tuned at two levels:
     pod:
       runAsNonRoot: true
       runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: "OnRootMismatch"
+      seccompProfile:
+        type: RuntimeDefault
+    container:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: false
+      capabilities:
+        drop:
+          - ALL
 
   # Per-component override (always available)
   pgwatch:

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -40,9 +40,11 @@ spec:
       labels:
         {{- include "pgwatch.commonLabels" (dict "root" . "component" "db-init") | nindent 8 }}
     spec:
+      {{- include "pgwatch.podSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.postgres.securityContext) | nindent 6 }}
       restartPolicy: OnFailure
       containers:
         - name: db-init
+          {{- include "pgwatch.containerSecurityContext" (dict "global" .Values.securityContext "component" .Values.pgwatch.postgres.securityContext) | nindent 10 }}
           image: {{ (include "pgwatch.postgres.newPgDatabase.image" .) }}
           env:
             - name: PGHOST

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -15,6 +15,8 @@ securityContext:
     runAsGroup: 1000
     fsGroup: 1000
     fsGroupChangePolicy: "OnRootMismatch"
+    seccompProfile:
+      type: RuntimeDefault
   # -- Container-level security context. https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#SecurityContext
   container:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Closes #31.

I've also added a fix that solved the securityContext handling of the db-init Job.