### PR TITLE
fix: honor TimescaleDB admin password key in db-init Job

### DIFF
--- a/helm/pgwatch/CHANGELOG.md
+++ b/helm/pgwatch/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `db-init` hook Job now honors `timescaledb.auth.secretKeys.adminPasswordKey` when TimescaleDB is enabled.
+
 ## [4.0.1] – 2026-05-26
 
 ### Added

--- a/helm/pgwatch/templates/_helpers.tpl
+++ b/helm/pgwatch/templates/_helpers.tpl
@@ -435,6 +435,15 @@ pgwatch.adminCredentialPasswordKey
 {{- end }}
 
 {{/*
+pgwatch.timescaledbAdminPasswordKey
+  Key containing the TimescaleDB postgres admin password.
+*/}}
+{{- define "pgwatch.timescaledbAdminPasswordKey" -}}
+{{- ((.Values.timescaledb.auth | default dict).secretKeys | default dict).adminPasswordKey
+    | default "postgres-password" -}}
+{{- end }}
+
+{{/*
 pgwatch.hasLegacyExternalDbInlineCredentials
   True when deprecated external DB username/password fields are still used.
 */}}

--- a/helm/pgwatch/templates/db-init-job.yaml
+++ b/helm/pgwatch/templates/db-init-job.yaml
@@ -13,7 +13,7 @@
 
   Admin credentials are sourced from:
     - TimescaleDB, generated secret  : Secret <release>-timescaledb           key postgres-password
-    - TimescaleDB, existingSecret    : Secret timescaledb.auth.existingSecret  key postgres-password
+    - TimescaleDB, existingSecret    : Secret timescaledb.auth.existingSecret  key timescaledb.auth.secretKeys.adminPasswordKey
     - Plain postgres                 : Secret pgwatch-postgresql-secret-postgres  key password
 
   The pgwatch user credentials are sourced from:
@@ -58,7 +58,7 @@ spec:
                 secretKeyRef:
                   {{- if .Values.timescaledb.enabled }}
                   name: {{ .Values.timescaledb.auth.existingSecret | default (printf "%s-timescaledb" .Release.Name) }}
-                  key: postgres-password
+                  key: {{ include "pgwatch.timescaledbAdminPasswordKey" . }}
                   {{- else }}
                   name: {{ include "pgwatch.adminCredentialSecretName" . }}
                   key: {{ include "pgwatch.adminCredentialPasswordKey" . }}


### PR DESCRIPTION
Use timescaledb.auth.secretKeys.adminPasswordKey when sourcing the TimescaleDB admin password for the db-init hook Job, while preserving postgres-password as the default key.

Closes #36