### PR TITLE
fix: pin pgwatch image tag to Chart.AppVersion instead of latest

### DIFF
--- a/helm/pgwatch/templates/pgwatch-deployment.yaml
+++ b/helm/pgwatch/templates/pgwatch-deployment.yaml
@@ -76,7 +76,7 @@ spec:
           envFrom:
             {{- toYaml . | nindent 12 }}
         {{- end }}
-          image: {{ .Values.pgwatch.image }}
+          image: {{ .Values.pgwatch.image }}:{{ .Chart.AppVersion }}
           volumeMounts:
           - name: launcher
             mountPath: /tmp/launcher.sh

--- a/helm/pgwatch/values.yaml
+++ b/helm/pgwatch/values.yaml
@@ -41,7 +41,7 @@ pgwatch:
 
   # == Core Settings ==
 
-  image: "docker.io/cybertecpostgresql/pgwatch:latest"
+  image: "docker.io/cybertecpostgresql/pgwatch"
   # -- Web UI listen port. Must match PW_WEBADDR (default :8080). Used for containerPort and Service.
   webPort: 8080
 


### PR DESCRIPTION
Fixes #39

## Changes
- Removed `:latest` tag from `helm/pgwatch/values.yaml`
- Updated `helm/pgwatch/templates/pgwatch-deployment.yaml` 
  to use `{{ .Chart.AppVersion }}` for the image tag

## Why
- Makes deployments reproducible
- Prevents stale image issues in Kubernetes