### PR TITLE
Add legacy test scenarios and relevant documentation

### DIFF
--- a/helm/pgwatch/templates/NOTES.txt
+++ b/helm/pgwatch/templates/NOTES.txt
@@ -57,19 +57,6 @@ Please migrate to one of the new secret-backed options:
   - pgwatch.postgres.credentials.existingSecret
 {{- end }}
 
-{{- if or (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
-          (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
-
-Credential Secret:
-  kubectl get secret {{ include "pgwatch.credentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
-{{- end }}
-
-{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
-          (not .Values.timescaledb.enabled) }}
-Postgres Admin Secret:
-  kubectl get secret {{ include "pgwatch.adminCredentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
-{{- end }}
-
 {{- if kindIs "string" .Values.pgwatch.image }}
 WARNING:
 Detected legacy string value for pgwatch.image.
@@ -82,4 +69,17 @@ major release. Please migrate to the new structured format:
       repository: "docker.io/cybertecpostgresql/pgwatch"
       tag: ""  # empty defaults to .Chart.AppVersion
 
+{{- end }}
+
+{{- if or (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
+          (include "pgwatch.postgres.hasUseExistingDatabase" .) }}
+
+Credential Secret:
+  kubectl get secret {{ include "pgwatch.credentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
+{{- end }}
+
+{{- if and (include "pgwatch.isTrue" (include "pgwatch.postgres.createMetricDatabase" .))
+          (not .Values.timescaledb.enabled) }}
+Postgres Admin Secret:
+  kubectl get secret {{ include "pgwatch.adminCredentialSecretName" . }} -n {{ .Release.Namespace }} -o yaml
 {{- end }}

--- a/helm/pgwatch/test_scenarios/README.md
+++ b/helm/pgwatch/test_scenarios/README.md
@@ -1,0 +1,12 @@
+# Test Scenarios
+
+Manual values files for exercising specific chart behaviors during development.
+Each file documents its own verify/expected-output steps in its header comment.
+
+- [`legacy-bool-values.yaml`](legacy-bool-values.yaml) — legacy string-boolean fallback
+- [`legacy-snakecase-values.yaml`](legacy-snakecase-values.yaml) — legacy snake_case key fallback
+- [`legacy-inline-db-credentials-values.yaml`](legacy-inline-db-credentials-values.yaml) — deprecated inline DB credentials fallback
+- [`legacy-image-string-values.yaml`](legacy-image-string-values.yaml) — deprecated plain-string `pgwatch.image` fallback
+- [`env-merge-override.yaml`](env-merge-override.yaml) — user `env` values override chart defaults
+- [`env-merge-reserved-key.yaml`](env-merge-reserved-key.yaml) — reserved env key fails the render
+- [`env-merge-envfrom-precedence.yaml`](env-merge-envfrom-precedence.yaml) — explicit `env` wins over `envFrom`

--- a/helm/pgwatch/test_scenarios/legacy-bool-values.yaml
+++ b/helm/pgwatch/test_scenarios/legacy-bool-values.yaml
@@ -1,0 +1,39 @@
+# Verifies the legacy string-boolean fallback ("true"/"false" instead of
+# native YAML booleans). Uses camelCase keys throughout — only the VALUE
+# type is legacy here, not the key names — to isolate this single
+# deprecation from the snake_case key fallback (see
+# legacy-snakecase-values.yaml for that one).
+#
+# Built-in PostgreSQL credentials are set so the render succeeds.
+#
+# Verify with:
+#   helm install pgwatch . -n pgwatch-legacy-test --create-namespace \
+#     -f test_scenarios/legacy-bool-values.yaml --dry-run --debug
+#
+# Expected: the render SUCCEEDS, and NOTES.txt prints exactly ONE WARNING
+# block: "Detected legacy string boolean values" — no snake_case, inline
+# credential, or image-string warnings should appear.
+
+pgwatch:
+  postgres:
+    enablePgSink: "true"
+    createMetricDatabase: "true"
+
+    credentials:
+      username: pgwatch
+      password: pgwatchtest
+    adminCredentials:
+      password: pgwatchadmin
+
+  prometheus:
+    enablePromSink: "true"
+    newPrometheus:
+      # Keep "false": this disables the Prometheus Deployment, keeping the
+      # scenario focused on the boolean fallback rather than a full deploy.
+      createPrometheus: "false"
+
+  grafana:
+    enableGrafana: "true"
+    enableDatasources:
+      postgres: "true"
+      prometheus: "true"

--- a/helm/pgwatch/test_scenarios/legacy-image-string-values.yaml
+++ b/helm/pgwatch/test_scenarios/legacy-image-string-values.yaml
@@ -1,0 +1,32 @@
+# Verifies the deprecated plain-string pgwatch.image fallback (replacement
+# is the structured { repository, tag } format introduced when image was
+# split into separate fields, see CHANGELOG.md "Deprecated"). Everything
+# else uses current camelCase keys and native booleans, to isolate this
+# single deprecation from the others.
+#
+# Built-in PostgreSQL credentials are set so the render succeeds.
+#
+# Verify with:
+#   helm install pgwatch . -n pgwatch-legacy-test --create-namespace \
+#     -f test_scenarios/legacy-image-string-values.yaml --dry-run --debug
+#
+# Expected: the render SUCCEEDS, and NOTES.txt prints exactly ONE WARNING
+# block: "Detected legacy string value for pgwatch.image" — no
+# string-boolean, snake_case, or inline-credential warnings should appear.
+#
+# `helm template`/`helm install` also print a benign Helm-internal notice:
+#   coalesce.go: warning: cannot overwrite table with non table for
+#   pgwatch.pgwatch.image (map[repository:... tag:])
+# This is expected noise from overriding the structured image default with
+# a plain string — exactly the deprecated behavior under test — and is
+# unrelated to the WARNING block above.
+
+pgwatch:
+  image: "docker.io/cybertecpostgresql/pgwatch"
+
+  postgres:
+    credentials:
+      username: pgwatch
+      password: pgwatchtest
+    adminCredentials:
+      password: pgwatchadmin

--- a/helm/pgwatch/test_scenarios/legacy-inline-db-credentials-values.yaml
+++ b/helm/pgwatch/test_scenarios/legacy-inline-db-credentials-values.yaml
@@ -1,0 +1,27 @@
+# Verifies the deprecated inline useExistingDatabase.username/password
+# fallback. Uses camelCase keys and native booleans throughout — only the
+# inline credentials are legacy here — to isolate this single deprecation
+# from the snake_case/string-boolean fallbacks.
+#
+# The deprecated username/password double as the only application-user
+# credentials supplied (no pgwatch.postgres.credentials.password is set),
+# so the fallback path is actually exercised rather than shadowed.
+#
+# Verify with:
+#   helm install pgwatch . -n pgwatch-legacy-test --create-namespace \
+#     -f test_scenarios/legacy-inline-db-credentials-values.yaml --dry-run --debug
+#
+# Expected: the render SUCCEEDS, and NOTES.txt prints exactly ONE WARNING
+# block: "Detected deprecated inline external database credentials" — no
+# string-boolean, snake_case, or image-string warnings should appear.
+
+pgwatch:
+  postgres:
+    createMetricDatabase: false
+    useExistingDatabase:
+      endpoint: postgresql.local
+      port: "5432"
+      database: pgwatch_metrics
+      sslmode: require
+      username: pgwatch_user   # deprecated, see pgwatch.postgres.credentials
+      password: change-me      # deprecated, see pgwatch.postgres.credentials

--- a/helm/pgwatch/test_scenarios/legacy-snakecase-values.yaml
+++ b/helm/pgwatch/test_scenarios/legacy-snakecase-values.yaml
@@ -1,0 +1,52 @@
+# Verifies the legacy snake_case value-key fallback (renamed to camelCase).
+# Uses native YAML booleans throughout — only the KEY names are legacy here,
+# not the value types — to isolate this single deprecation from the
+# string-boolean fallback (see legacy-bool-values.yaml for that one).
+#
+# Built-in PostgreSQL credentials are set so the render succeeds.
+#
+# Verify with:
+#   helm install pgwatch . -n pgwatch-legacy-test --create-namespace \
+#     -f test_scenarios/legacy-snakecase-values.yaml --dry-run --debug
+#
+# Expected: the render SUCCEEDS, and NOTES.txt prints exactly ONE WARNING
+# block: "Detected legacy snake_case values" — no string-boolean, inline
+# credential, or image-string warnings should appear.
+
+pgwatch:
+  postgres:
+    enable_pg_sink: true
+    settings:
+      retention_days: 7
+    create_metric_database: true
+
+    # Required once new_pg_database is present at all: the helper that
+    # resolves the StatefulSet image/volume swaps to this snake_case block
+    # entirely (no per-field fallback to the camelCase chart defaults), so
+    # these values must be supplied explicitly here.
+    new_pg_database:
+      image: "docker.io/postgres:18.3-alpine3.23"
+      volume:
+        size: "10Gi"
+        storageClass: "standard"
+
+    credentials:
+      username: pgwatch
+      password: pgwatchtest
+    adminCredentials:
+      password: pgwatchadmin
+
+  prometheus:
+    enable_prom_sink: true
+    new_prometheus:
+      # Keep false: this disables the Prometheus Deployment, keeping the
+      # scenario focused on the snake_case fallback rather than a full
+      # deploy. No other new_prometheus fields are needed since the
+      # Prometheus Deployment/Config/Alert templates are skipped entirely.
+      create_prometheus: false
+
+  grafana:
+    enable_grafana: true
+    enable_datasources:
+      postgres: true
+      prometheus: true


### PR DESCRIPTION
Also, the Credential Secret Note is moved to the end, so that the users would see it as the latest Note from the installation.

Later on, in the future, those tests can be better organized, e.g. CI workflow.